### PR TITLE
Support for sending metrics over StatsD

### DIFF
--- a/cmd/dkvsrv/main.go
+++ b/cmd/dkvsrv/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
+	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -85,20 +85,20 @@ func main() {
 
 	switch srvrRole {
 	case noRole:
-		dkvSvc := master.NewStandaloneService(kvs, nil, br, dkvLogger)
+		dkvSvc := master.NewStandaloneService(kvs, nil, br, dkvLogger, statsCli)
 		defer dkvSvc.Close()
 		serverpb.RegisterDKVServer(grpcSrvr, dkvSvc)
 		serverpb.RegisterDKVBackupRestoreServer(grpcSrvr, dkvSvc)
 	case masterRole:
 		if cp == nil {
-			panic(fmt.Sprintf("Storage engine %s is not supported for DKV master role.", dbEngine))
+			log.Panicf("Storage engine %s is not supported for DKV master role.", dbEngine)
 		}
 		var dkvSvc master.DKVService
 		if haveFlagsWithPrefix("nexus") {
-			dkvSvc = master.NewDistributedService(kvs, cp, br, newDKVReplicator(kvs), dkvLogger)
+			dkvSvc = master.NewDistributedService(kvs, cp, br, newDKVReplicator(kvs), dkvLogger, statsCli)
 			serverpb.RegisterDKVClusterServer(grpcSrvr, dkvSvc.(master.DKVClusterService))
 		} else {
-			dkvSvc = master.NewStandaloneService(kvs, cp, br, dkvLogger)
+			dkvSvc = master.NewStandaloneService(kvs, cp, br, dkvLogger, statsCli)
 			serverpb.RegisterDKVBackupRestoreServer(grpcSrvr, dkvSvc)
 		}
 		defer dkvSvc.Close()
@@ -109,7 +109,7 @@ func main() {
 			panic(err)
 		} else {
 			defer replCli.Close()
-			dkvSvc, _ := slave.NewService(kvs, ca, replCli, replPollInterval, dkvLogger)
+			dkvSvc, _ := slave.NewService(kvs, ca, replCli, replPollInterval, dkvLogger, statsCli)
 			defer dkvSvc.Close()
 			serverpb.RegisterDKVServer(grpcSrvr, dkvSvc)
 		}
@@ -118,23 +118,22 @@ func main() {
 	}
 	go grpcSrvr.Serve(lstnr)
 	sig := <-setupSignalHandler()
-	fmt.Printf("[WARN] Caught signal: %v. Shutting down...\n", sig)
+	log.Printf("[WARN] Caught signal: %v. Shutting down...\n", sig)
 }
 
 func validateFlags() {
 	if dbListenAddr != "" && strings.IndexRune(dbListenAddr, ':') < 0 {
-		panic(fmt.Errorf("given listen address: %s is invalid, must be in host:port format", dbListenAddr))
+		log.Panicf("given listen address: %s is invalid, must be in host:port format", dbListenAddr)
 	}
 	if replMasterAddr != "" && strings.IndexRune(replMasterAddr, ':') < 0 {
-		panic(fmt.Errorf("given master address: %s for replication is invalid, must be in host:port format", replMasterAddr))
+		log.Panicf("given master address: %s for replication is invalid, must be in host:port format", replMasterAddr)
 	}
 	if statsdAddr != "" && strings.IndexRune(statsdAddr, ':') < 0 {
-		panic(fmt.Errorf("given StatsD address: %s is invalid, must be in host:port format", statsdAddr))
+		log.Panicf("given StatsD address: %s is invalid, must be in host:port format", statsdAddr)
 	}
 }
 
 func setupAccessLogger() {
-	accessLogger = zap.NewNop()
 	if dbAccessLog != "" {
 		accessLoggerConfig := zap.Config{
 			Level:         zap.NewAtomicLevelAt(zap.InfoLevel),
@@ -160,7 +159,8 @@ func setupAccessLogger() {
 			ErrorOutputPaths: []string{dbAccessLog},
 		}
 		if lg, err := accessLoggerConfig.Build(); err != nil {
-			panic(err)
+			log.Printf("[WARN] Unable to configure access logger. Error: %v\n", err)
+			accessLogger = zap.NewNop()
 		} else {
 			accessLogger = lg
 		}
@@ -197,7 +197,8 @@ func setupDKVLogger() {
 	}
 
 	if lg, err := dkvLoggerConfig.Build(); err != nil {
-		panic(err)
+		log.Printf("[WARN] Unable to configure DKV logger. Error: %v\n", err)
+		dkvLogger = zap.NewNop()
 	} else {
 		dkvLogger = lg
 	}
@@ -211,12 +212,13 @@ func newGrpcServerListener() (*grpc.Server, net.Listener) {
 	return grpcSrvr, newListener()
 }
 
-func newListener() net.Listener {
-	if lis, err := net.Listen("tcp", dbListenAddr); err != nil {
-		panic(fmt.Sprintf("failed to listen: %v", err))
-	} else {
-		return lis
+func newListener() (lis net.Listener) {
+	var err error
+	if lis, err = net.Listen("tcp", dbListenAddr); err != nil {
+		log.Panicf("failed to listen: %v", err)
+		return
 	}
+	return
 }
 
 func setupSignalHandler() <-chan os.Signal {
@@ -237,11 +239,11 @@ func haveFlagsWithPrefix(prefix string) bool {
 }
 
 func printFlagsWithPrefix(prefixes ...string) {
-	fmt.Println("Launching DKV server with following flags:")
+	log.Println("Launching DKV server with following flags:")
 	flag.VisitAll(func(f *flag.Flag) {
 		for _, pf := range prefixes {
 			if strings.HasPrefix(f.Name, pf) {
-				fmt.Printf("%s (%s): %v\n", f.Name, f.Usage, f.Value)
+				log.Printf("%s (%s): %v\n", f.Name, f.Usage, f.Value)
 			}
 		}
 	})
@@ -331,10 +333,10 @@ func newKVStore() (storage.KVStore, storage.ChangePropagator, storage.ChangeAppl
 
 func mkdirNexusDirs() {
 	if err := os.MkdirAll(nexusLogDirFlag.Value.String(), 0777); err != nil {
-		panic(fmt.Sprintf("Unable to create Nexus logDir. Error: %v", err))
+		log.Panicf("Unable to create Nexus logDir. Error: %v", err)
 	}
 	if err := os.MkdirAll(nexusSnapDirFlag.Value.String(), 0777); err != nil {
-		panic(fmt.Sprintf("Unable to create Nexus snapDir. Error: %v", err))
+		log.Panicf("Unable to create Nexus snapDir. Error: %v", err)
 	}
 }
 

--- a/cmd/dkvsrv/main.go
+++ b/cmd/dkvsrv/main.go
@@ -123,13 +123,13 @@ func main() {
 
 func validateFlags() {
 	if dbListenAddr != "" && strings.IndexRune(dbListenAddr, ':') < 0 {
-		panic(fmt.Errorf("Given listen address: %s is invalid. Must be in host:port format.", dbListenAddr))
+		panic(fmt.Errorf("given listen address: %s is invalid, must be in host:port format", dbListenAddr))
 	}
 	if replMasterAddr != "" && strings.IndexRune(replMasterAddr, ':') < 0 {
-		panic(fmt.Errorf("Given master address: %s for replication is invalid. Must be in host:port format.", replMasterAddr))
+		panic(fmt.Errorf("given master address: %s for replication is invalid, must be in host:port format", replMasterAddr))
 	}
 	if statsdAddr != "" && strings.IndexRune(statsdAddr, ':') < 0 {
-		panic(fmt.Errorf("Given StatsD address: %s is invalid. Must be in host:port format.", statsdAddr))
+		panic(fmt.Errorf("given StatsD address: %s is invalid, must be in host:port format", statsdAddr))
 	}
 }
 
@@ -305,13 +305,20 @@ func newKVStore() (storage.KVStore, storage.ChangePropagator, storage.ChangeAppl
 	slg.Infof("Using %s as data folder", dbDir)
 	switch dbEngine {
 	case "rocksdb":
-		rocksDb, err := rocksdb.OpenDBWithLogger(dbDir, cacheSize, dkvLogger)
+		rocksDb, err := rocksdb.OpenDB(dbDir,
+			rocksdb.WithCacheSize(cacheSize),
+			rocksdb.WithStats(statsCli),
+			rocksdb.WithLogger(dkvLogger))
 		if err != nil {
 			dkvLogger.Panic("RocksDB engine init failed", zap.Error(err))
 		}
 		return rocksDb, rocksDb, rocksDb, rocksDb
 	case "badger":
-		badgerDb, err := badger.OpenDBWithLogger(dbDir, dkvLogger)
+		badgerDb, err := badger.OpenDB(dbDir,
+			badger.WithLogger(dkvLogger),
+			badger.WithSyncWrites(),
+			badger.WithStats(statsCli),
+			badger.WithoutDBInternalLogging())
 		if err != nil {
 			dkvLogger.Panic("Badger engine init failed", zap.Error(err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/prometheus/procfs v0.0.10 // indirect
+	github.com/smira/go-statsd v1.3.1
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c
 	go.uber.org/zap v1.14.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/internal/server/master/ds_service_test.go
+++ b/internal/server/master/ds_service_test.go
@@ -209,7 +209,7 @@ func newKVStoreWithID(id int) (storage.KVStore, storage.ChangePropagator, storag
 	}
 	switch engine {
 	case "rocksdb":
-		rocksDb, err := rocksdb.OpenDB(dbFolder, cacheSize)
+		rocksDb, err := rocksdb.OpenDB(dbFolder, rocksdb.WithCacheSize(cacheSize))
 		if err != nil {
 			panic(err)
 		}

--- a/internal/server/master/ds_service_test.go
+++ b/internal/server/master/ds_service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flipkart-incubator/dkv/internal/server/stats"
 	"github.com/flipkart-incubator/dkv/internal/server/storage"
 	"github.com/flipkart-incubator/dkv/internal/server/storage/badger"
 	"github.com/flipkart-incubator/dkv/internal/server/storage/rocksdb"
@@ -17,6 +18,7 @@ import (
 	"github.com/flipkart-incubator/dkv/pkg/serverpb"
 	nexus_api "github.com/flipkart-incubator/nexus/pkg/api"
 	nexus "github.com/flipkart-incubator/nexus/pkg/raft"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -229,7 +231,7 @@ func newDistributedDKVNode(id int, join bool, clusURL string) (DKVService, *grpc
 	kvs, cp, br := newKVStoreWithID(id)
 	dkvRepl := newReplicator(id, kvs, join, clusURL)
 	dkvRepl.Start()
-	distSrv := NewDistributedService(kvs, cp, br, dkvRepl, nil)
+	distSrv := NewDistributedService(kvs, cp, br, dkvRepl, zap.NewNop(), stats.NewNoOpClient())
 	grpcSrv := grpc.NewServer()
 	serverpb.RegisterDKVServer(grpcSrv, distSrv)
 	serverpb.RegisterDKVClusterServer(grpcSrv, distSrv)

--- a/internal/server/master/ss_service_test.go
+++ b/internal/server/master/ss_service_test.go
@@ -224,7 +224,7 @@ func newKVStore() (storage.KVStore, storage.ChangePropagator, storage.Backupable
 	}
 	switch engine {
 	case "rocksdb":
-		rocksDb, err := rocksdb.OpenDB(dbFolder, cacheSize)
+		rocksDb, err := rocksdb.OpenDB(dbFolder, rocksdb.WithCacheSize(cacheSize))
 		if err != nil {
 			panic(err)
 		}

--- a/internal/server/master/ss_service_test.go
+++ b/internal/server/master/ss_service_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flipkart-incubator/dkv/internal/server/stats"
 	"github.com/flipkart-incubator/dkv/internal/server/storage"
 	"github.com/flipkart-incubator/dkv/internal/server/storage/badger"
 	"github.com/flipkart-incubator/dkv/internal/server/storage/rocksdb"
 	"github.com/flipkart-incubator/dkv/pkg/ctl"
 	"github.com/flipkart-incubator/dkv/pkg/serverpb"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -242,7 +244,7 @@ func newKVStore() (storage.KVStore, storage.ChangePropagator, storage.Backupable
 
 func serveStandaloneDKV() {
 	kvs, cp, ba := newKVStore()
-	dkvSvc = NewStandaloneService(kvs, cp, ba, nil)
+	dkvSvc = NewStandaloneService(kvs, cp, ba, zap.NewNop(), stats.NewNoOpClient())
 	grpcSrvr = grpc.NewServer()
 	serverpb.RegisterDKVServer(grpcSrvr, dkvSvc)
 	serverpb.RegisterDKVReplicationServer(grpcSrvr, dkvSvc)

--- a/internal/server/slave/service_test.go
+++ b/internal/server/slave/service_test.go
@@ -133,7 +133,7 @@ func newRocksDBStore(dbFolder string) rocksdb.DB {
 	if err := exec.Command("rm", "-rf", dbFolder).Run(); err != nil {
 		panic(err)
 	}
-	store, err := rocksdb.OpenDB(dbFolder, cacheSize)
+	store, err := rocksdb.OpenDB(dbFolder, rocksdb.WithCacheSize(cacheSize))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/server/stats/client.go
+++ b/internal/server/stats/client.go
@@ -1,0 +1,74 @@
+package stats
+
+import (
+	"io"
+	"time"
+
+	"github.com/smira/go-statsd"
+)
+
+type Tag struct {
+	key, val string
+}
+
+func NewTag(key, val string) Tag {
+	return Tag{key, val}
+}
+
+type Client interface {
+	io.Closer
+	Incr(string, int64)
+	Gauge(string, int64)
+	GaugeDelta(string, int64)
+	Timing(string, time.Time)
+}
+
+type noopClient struct{}
+
+func (*noopClient) Incr(_ string, _ int64)       {}
+func (*noopClient) Gauge(_ string, _ int64)      {}
+func (*noopClient) GaugeDelta(_ string, _ int64) {}
+func (*noopClient) Timing(_ string, _ time.Time) {}
+func (*noopClient) Close() error                 { return nil }
+
+func NewNoOpClient() *noopClient {
+	return &noopClient{}
+}
+
+type statsDClient struct {
+	cli *statsd.Client
+}
+
+func NewStatsDClient(statsdAddr, metricPrfx string, defTags ...Tag) *statsDClient {
+	statsTags := make([]statsd.Tag, len(defTags))
+	for i, defTag := range defTags {
+		statsTags[i] = statsd.StringTag(defTag.key, defTag.val)
+	}
+	return &statsDClient{
+		statsd.NewClient(
+			statsdAddr,
+			statsd.TagStyle(statsd.TagFormatDatadog),
+			statsd.MetricPrefix(metricPrfx),
+			statsd.DefaultTags(statsTags...)),
+	}
+}
+
+func (sdc *statsDClient) Incr(name string, value int64) {
+	sdc.cli.Incr(name, value)
+}
+
+func (sdc *statsDClient) Gauge(name string, value int64) {
+	sdc.cli.Gauge(name, value)
+}
+
+func (sdc *statsDClient) GaugeDelta(name string, value int64) {
+	sdc.cli.GaugeDelta(name, value)
+}
+
+func (sdc *statsDClient) Timing(name string, startTime time.Time) {
+	sdc.cli.PrecisionTiming(name, time.Since(startTime))
+}
+
+func (sdc *statsDClient) Close() error {
+	return sdc.cli.Close()
+}

--- a/internal/server/stats/client.go
+++ b/internal/server/stats/client.go
@@ -7,14 +7,19 @@ import (
 	"github.com/smira/go-statsd"
 )
 
+// Tag represents the key value pair that is sent
+// along with every measurement to a metrics sink.
 type Tag struct {
 	key, val string
 }
 
+// NewTag creates an instance of the Tag type.
 func NewTag(key, val string) Tag {
 	return Tag{key, val}
 }
 
+// Client exposes all the behavior for capturing and
+// and sending various measurements to a metrics sink.
 type Client interface {
 	io.Closer
 	Incr(string, int64)
@@ -31,7 +36,9 @@ func (*noopClient) GaugeDelta(_ string, _ int64) {}
 func (*noopClient) Timing(_ string, _ time.Time) {}
 func (*noopClient) Close() error                 { return nil }
 
-func NewNoOpClient() *noopClient {
+// NewNoOpClient creates a metrics client that does
+// not send any measurements.
+func NewNoOpClient() Client {
 	return &noopClient{}
 }
 
@@ -39,7 +46,9 @@ type statsDClient struct {
 	cli *statsd.Client
 }
 
-func NewStatsDClient(statsdAddr, metricPrfx string, defTags ...Tag) *statsDClient {
+// NewStatsDClient creates a metrics client that sends
+// various measurements to StatsD client.
+func NewStatsDClient(statsdAddr, metricPrfx string, defTags ...Tag) Client {
 	statsTags := make([]statsd.Tag, len(defTags))
 	for i, defTag := range defTags {
 		statsTags[i] = statsd.StringTag(defTag.key, defTag.val)

--- a/internal/server/stats/client_test.go
+++ b/internal/server/stats/client_test.go
@@ -1,0 +1,103 @@
+package stats
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	serverPort          = 8125
+	adminPort           = 8126
+	statsDHost          = "127.0.0.1"
+	flushIntervalPrefix = "flushInterval:"
+)
+
+func TestStatsDClient(t *testing.T) {
+	addr := fmt.Sprintf("%s:%d", statsDHost, serverPort)
+	tags := []Tag{NewTag("Tag1", "1"), NewTag("Tag2", "2"), NewTag("Tag3", "3")}
+	statsCli := NewStatsDClient(addr, "nexus_test", tags...)
+	defer statsCli.Close()
+
+	statsdAdminUrl := fmt.Sprintf("%s:%d", statsDHost, adminPort)
+	conn := connectToStatsD(t, statsdAdminUrl)
+
+	s, w := bufio.NewScanner(conn), bufio.NewWriter(conn)
+	//flushDuration := statsdFlushInterval(s, w)
+	flushDuration := time.Duration(500) * time.Millisecond
+
+	statsCli.GaugeDelta("sample.gauge", 42)
+	<-time.After(flushDuration)
+	sendCommand("gauges", w)
+	logOutput(t, s)
+
+	statsCli.GaugeDelta("sample.gauge", -42)
+	<-time.After(flushDuration)
+	sendCommand("gauges", w)
+	logOutput(t, s)
+
+	statsCli.GaugeDelta("sample.gauge", 42)
+	<-time.After(flushDuration)
+	sendCommand("gauges", w)
+	logOutput(t, s)
+
+	statsCli.Incr("sample.counter", 5)
+	<-time.After(flushDuration)
+	sendCommand("counters", w)
+	logOutput(t, s)
+
+	timing(statsCli)
+	<-time.After(flushDuration)
+	sendCommand("timers", w)
+	logOutput(t, s)
+}
+
+func timing(statsCli Client) {
+	defer statsCli.Timing("sample.timing", time.Now())
+	<-time.After(10 * time.Millisecond)
+}
+
+func statsdFlushInterval(s *bufio.Scanner, w *bufio.Writer) time.Duration {
+	sendCommand("config", w)
+	for s.Scan() {
+		msg := s.Text()
+		if strings.HasPrefix(msg, flushIntervalPrefix) {
+			idx := strings.IndexRune(msg, ':') + 2
+			flushDuration, _ := strconv.Atoi(msg[idx:])
+			return time.Duration(flushDuration) * time.Millisecond
+		}
+	}
+	return 10 * time.Millisecond
+}
+
+func connectToStatsD(t *testing.T, statsdAdminUrl string) net.Conn {
+	conn, err := net.Dial("tcp", statsdAdminUrl)
+	if err != nil {
+		t.Logf("Unable to connect to StatsD admin endpoint: %s. Skipping this test.", statsdAdminUrl)
+		os.Exit(0)
+	}
+	return conn
+}
+
+func sendCommand(cmd string, w *bufio.Writer) {
+	fmt.Fprint(w, cmd)
+	w.Flush()
+}
+
+func logOutput(t *testing.T, scanner *bufio.Scanner) {
+	for scanner.Scan() {
+		msg := scanner.Text()
+		t.Logf(msg)
+		if msg == "END" {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/server/stats/client_test.go
+++ b/internal/server/stats/client_test.go
@@ -24,8 +24,8 @@ func TestStatsDClient(t *testing.T) {
 	statsCli := NewStatsDClient(addr, "nexus_test", tags...)
 	defer statsCli.Close()
 
-	statsdAdminUrl := fmt.Sprintf("%s:%d", statsDHost, adminPort)
-	conn := connectToStatsD(t, statsdAdminUrl)
+	statsdAdminURL := fmt.Sprintf("%s:%d", statsDHost, adminPort)
+	conn := connectToStatsD(t, statsdAdminURL)
 
 	s, w := bufio.NewScanner(conn), bufio.NewWriter(conn)
 	//flushDuration := statsdFlushInterval(s, w)
@@ -75,10 +75,10 @@ func statsdFlushInterval(s *bufio.Scanner, w *bufio.Writer) time.Duration {
 	return 10 * time.Millisecond
 }
 
-func connectToStatsD(t *testing.T, statsdAdminUrl string) net.Conn {
-	conn, err := net.Dial("tcp", statsdAdminUrl)
+func connectToStatsD(t *testing.T, statsdAdminURL string) net.Conn {
+	conn, err := net.Dial("tcp", statsdAdminURL)
 	if err != nil {
-		t.Logf("Unable to connect to StatsD admin endpoint: %s. Skipping this test.", statsdAdminUrl)
+		t.Logf("Unable to connect to StatsD admin endpoint: %s. Skipping this test.", statsdAdminURL)
 		os.Exit(0)
 	}
 	return conn

--- a/internal/server/storage/badger/store_test.go
+++ b/internal/server/storage/badger/store_test.go
@@ -14,7 +14,6 @@ import (
 	badger_pb "github.com/dgraph-io/badger/pb"
 	"github.com/flipkart-incubator/dkv/internal/server/storage"
 	"github.com/flipkart-incubator/dkv/pkg/serverpb"
-	"go.uber.org/zap"
 )
 
 const dbFolder = "/tmp/badger_storage_test"
@@ -647,5 +646,6 @@ func openBadgerDB() (*badgerDB, error) {
 	if err := exec.Command("rm", "-rf", dbFolder).Run(); err != nil {
 		return nil, err
 	}
-	return openStore(NewOptions(dbFolder), zap.NewNop())
+	kvs, err := OpenDB(dbFolder)
+	return kvs.(*badgerDB), err
 }

--- a/internal/server/storage/rocksdb/store_test.go
+++ b/internal/server/storage/rocksdb/store_test.go
@@ -639,6 +639,6 @@ func openRocksDB() (*rocksDB, error) {
 	if err := exec.Command("rm", "-rf", dbFolder).Run(); err != nil {
 		return nil, err
 	}
-	db, err := OpenDB(dbFolder, cacheSize)
+	db, err := OpenDB(dbFolder, WithCacheSize(cacheSize))
 	return db.(*rocksDB), err
 }


### PR DESCRIPTION
Fixes #10 

Following changes are involved:

1. Stats adapter for StatsD
2. Injecting the adapter in service and storage layers
3. Sending key metrics in storage layers - timers and error counters during for PUT, GET and MultiGET operations.
