### PR TITLE
Java client support for CAS operations

### DIFF
--- a/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
@@ -4,6 +4,8 @@ import dkv.serverpb.Api;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
 
 /**
  * Provides the means to interact with DKV GRPC APIs. Implementors are
@@ -41,20 +43,32 @@ public interface DKVClient extends Closeable {
      */
     void put(byte[] key, byte[] value);
 
-    /**
-     * Retrieves the value associated with the given key from the DKV
-     * database. How recent the value needs to be can be controlled
-     * through the <tt>consistency</tt> parameter.
-     *
-     * @param consistency consistency controls how recent the result
-     *                    needs to be
-     * @param key key whose associated value needs to be retrieved
-     * @return the value associated with the given key in the database
-     * @throws DKVException if the underlying status in the response from
-     * the database is an error status
-     *
-     * @see Api.ReadConsistency
-     */
+    boolean compareAndSet(byte[] key, byte[] expect, byte[] update);
+
+    long incrementAndGet(byte[] key);
+
+    <T extends Number> T decrementAndGet(byte[] key);
+
+    <T extends Number> T addAndGet(byte[] key, T delta);
+
+    <T extends Number> T accumulateAndGet(byte[] key, BinaryOperator<T> operator);
+
+    <T extends Number> T updateAndGet(byte[] key, UnaryOperator<T> operator);
+
+        /**
+         * Retrieves the value associated with the given key from the DKV
+         * database. How recent the value needs to be can be controlled
+         * through the <tt>consistency</tt> parameter.
+         *
+         * @param consistency consistency controls how recent the result
+         *                    needs to be
+         * @param key key whose associated value needs to be retrieved
+         * @return the value associated with the given key in the database
+         * @throws DKVException if the underlying status in the response from
+         * the database is an error status
+         *
+         * @see Api.ReadConsistency
+         */
     String get(Api.ReadConsistency consistency, String key);
 
     /**

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
@@ -4,8 +4,6 @@ import dkv.serverpb.Api;
 
 import java.io.Closeable;
 import java.util.Iterator;
-import java.util.function.BinaryOperator;
-import java.util.function.UnaryOperator;
 
 /**
  * Provides the means to interact with DKV GRPC APIs. Implementors are

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/DKVClient.java
@@ -43,32 +43,60 @@ public interface DKVClient extends Closeable {
      */
     void put(byte[] key, byte[] value);
 
+    /**
+     * Performs the compare and set operation on the specified key. The
+     * given expected value is compared with the existing value and if
+     * there is a match, that value is overwritten with the given value.
+     *
+     * @param key key used for this compare and set operation
+     * @param expect value to be expected as the existing value
+     * @param update new value to be set if the comparison succeeds
+     * @return true only if the given value is set against the key
+     */
     boolean compareAndSet(byte[] key, byte[] expect, byte[] update);
 
+    /**
+     * Atomically increments the current value associated with the given
+     * key and returns that value.
+     *
+     * @param key key used for this operation
+     * @return the value after the increment operation
+     */
     long incrementAndGet(byte[] key);
 
-    <T extends Number> T decrementAndGet(byte[] key);
+    /**
+     * Atomically decrements the current value associated with the given
+     * key and returns that value.
+     *
+     * @param key key used for this operation
+     * @return the value after the decrement operation
+     */
+    long decrementAndGet(byte[] key);
 
-    <T extends Number> T addAndGet(byte[] key, T delta);
+    /**
+     * Atomically adds the given delta to the current value associated
+     * with the given key and returns that value.
+     *
+     * @param key key used for this operation
+     * @param delta the value used for addition
+     * @return the value after the addition operation
+     */
+    long addAndGet(byte[] key, long delta);
 
-    <T extends Number> T accumulateAndGet(byte[] key, BinaryOperator<T> operator);
-
-    <T extends Number> T updateAndGet(byte[] key, UnaryOperator<T> operator);
-
-        /**
-         * Retrieves the value associated with the given key from the DKV
-         * database. How recent the value needs to be can be controlled
-         * through the <tt>consistency</tt> parameter.
-         *
-         * @param consistency consistency controls how recent the result
-         *                    needs to be
-         * @param key key whose associated value needs to be retrieved
-         * @return the value associated with the given key in the database
-         * @throws DKVException if the underlying status in the response from
-         * the database is an error status
-         *
-         * @see Api.ReadConsistency
-         */
+    /**
+     * Retrieves the value associated with the given key from the DKV
+     * database. How recent the value needs to be can be controlled
+     * through the <tt>consistency</tt> parameter.
+     *
+     * @param consistency consistency controls how recent the result
+     *                    needs to be
+     * @param key key whose associated value needs to be retrieved
+     * @return the value associated with the given key in the database
+     * @throws DKVException if the underlying status in the response from
+     * the database is an error status
+     *
+     * @see Api.ReadConsistency
+     */
     String get(Api.ReadConsistency consistency, String key);
 
     /**

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -69,23 +69,13 @@ public class ShardedDKVClient implements DKVClient {
     }
 
     @Override
-    public <T extends Number> T decrementAndGet(byte[] key) {
-        return null;
+    public long decrementAndGet(byte[] key) {
+        return 0;
     }
 
     @Override
-    public <T extends Number> T addAndGet(byte[] key, T delta) {
-        return null;
-    }
-
-    @Override
-    public <T extends Number> T accumulateAndGet(byte[] key, BinaryOperator<T> operator) {
-        return null;
-    }
-
-    @Override
-    public <T extends Number> T updateAndGet(byte[] key, UnaryOperator<T> operator) {
-        return null;
+    public long addAndGet(byte[] key, long delta) {
+        return 0;
     }
 
     @Override

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -6,8 +6,6 @@ import dkv.serverpb.Api;
 
 import java.io.Closeable;
 import java.util.*;
-import java.util.function.BinaryOperator;
-import java.util.function.UnaryOperator;
 
 import static java.util.Collections.addAll;
 import static org.dkv.client.DKVNodeType.*;

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -60,22 +60,38 @@ public class ShardedDKVClient implements DKVClient {
 
     @Override
     public boolean compareAndSet(byte[] key, byte[] expect, byte[] update) {
-        return false;
+        DKVShard dkvShard = shardProvider.provideShard(key);
+        checkf(dkvShard != null, IllegalArgumentException.class, "unable to compute shard for the given key");
+        //noinspection ConstantConditions
+        DKVClient dkvClient = pool.getDKVClient(dkvShard, MASTER, UNKNOWN);
+        return dkvClient.compareAndSet(key, expect, update);
     }
 
     @Override
     public long incrementAndGet(byte[] key) {
-        return 0;
+        DKVShard dkvShard = shardProvider.provideShard(key);
+        checkf(dkvShard != null, IllegalArgumentException.class, "unable to compute shard for the given key");
+        //noinspection ConstantConditions
+        DKVClient dkvClient = pool.getDKVClient(dkvShard, MASTER, UNKNOWN);
+        return dkvClient.incrementAndGet(key);
     }
 
     @Override
     public long decrementAndGet(byte[] key) {
-        return 0;
+        DKVShard dkvShard = shardProvider.provideShard(key);
+        checkf(dkvShard != null, IllegalArgumentException.class, "unable to compute shard for the given key");
+        //noinspection ConstantConditions
+        DKVClient dkvClient = pool.getDKVClient(dkvShard, MASTER, UNKNOWN);
+        return dkvClient.decrementAndGet(key);
     }
 
     @Override
     public long addAndGet(byte[] key, long delta) {
-        return 0;
+        DKVShard dkvShard = shardProvider.provideShard(key);
+        checkf(dkvShard != null, IllegalArgumentException.class, "unable to compute shard for the given key");
+        //noinspection ConstantConditions
+        DKVClient dkvClient = pool.getDKVClient(dkvShard, MASTER, UNKNOWN);
+        return dkvClient.addAndGet(key, delta);
     }
 
     @Override

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -6,6 +6,8 @@ import dkv.serverpb.Api;
 
 import java.io.Closeable;
 import java.util.*;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
 
 import static java.util.Collections.addAll;
 import static org.dkv.client.DKVNodeType.*;
@@ -54,6 +56,36 @@ public class ShardedDKVClient implements DKVClient {
         //noinspection ConstantConditions
         DKVClient dkvClient = pool.getDKVClient(dkvShard, MASTER, UNKNOWN);
         dkvClient.put(key, value);
+    }
+
+    @Override
+    public boolean compareAndSet(byte[] key, byte[] expect, byte[] update) {
+        return false;
+    }
+
+    @Override
+    public long incrementAndGet(byte[] key) {
+        return 0;
+    }
+
+    @Override
+    public <T extends Number> T decrementAndGet(byte[] key) {
+        return null;
+    }
+
+    @Override
+    public <T extends Number> T addAndGet(byte[] key, T delta) {
+        return null;
+    }
+
+    @Override
+    public <T extends Number> T accumulateAndGet(byte[] key, BinaryOperator<T> operator) {
+        return null;
+    }
+
+    @Override
+    public <T extends Number> T updateAndGet(byte[] key, UnaryOperator<T> operator) {
+        return null;
     }
 
     @Override

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
@@ -6,14 +6,13 @@ import dkv.serverpb.DKVGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BinaryOperator;
-import java.util.function.UnaryOperator;
 
 import static com.google.protobuf.ByteString.*;
+import static org.dkv.client.Utils.convertToLong;
+import static org.dkv.client.Utils.covertToBytes;
 
 /**
  * An implementation of the {@link DKVClient} interface. It provides a convenient
@@ -156,76 +155,21 @@ public class SimpleDKVClient implements DKVClient {
     }
 
     public boolean compareAndSet(byte[] key, byte[] expect, byte[] update) {
-        ByteString keyByteStr = copyFrom(key);
-        ByteString expectByteStr = copyFrom(expect);
-        ByteString updateByteStr = copyFrom(update);
-        return cas(keyByteStr, expectByteStr, updateByteStr);
-    }
-
-    private boolean cas(ByteString keyByteStr, ByteString expectByteStr, ByteString updateByteStr) {
-        Api.CompareAndSetRequest.Builder casReqBuilder = Api.CompareAndSetRequest.newBuilder();
-        Api.CompareAndSetRequest casReq = casReqBuilder
-                .setKey(keyByteStr).setOldValue(expectByteStr).setNewValue(updateByteStr)
-                .build();
-        Api.CompareAndSetResponse casRes = blockingStub.compareAndSet(casReq);
-        Api.Status status = casRes.getStatus();
-        if (status.getCode() != 0) {
-            throw new DKVException(status, "CompareAndSet", new Object[]{keyByteStr, expectByteStr, updateByteStr});
-        }
-        return casRes.getUpdated();
+        ByteString expectByteStr = expect != null ? copyFrom(expect) : EMPTY;
+        return cas(copyFrom(key), expectByteStr, copyFrom(update));
     }
 
     public long incrementAndGet(byte[] key) {
+        return addAndGet(key, 1);
+    }
+
+    public long decrementAndGet(byte[] key) {
+        return addAndGet(key, -1);
+    }
+
+    public long addAndGet(byte[] key, long delta) {
         ByteString keyByteStr = copyFrom(key);
-        ByteString expValByteStr, updatedValByteStr;
-        long updatedVal;
-        do {
-            expValByteStr = get(Api.ReadConsistency.LINEARIZABLE, keyByteStr);
-            byte[] expValBytes = expValByteStr.toByteArray();
-            long expVal = convertToLong(expValBytes);
-            updatedVal = expVal + 1;
-            byte[] updatedValBts = covertToBytes(updatedVal);
-            updatedValByteStr = copyFrom(updatedValBts);
-        } while (!cas(keyByteStr, expValByteStr, updatedValByteStr));
-        return updatedVal;
-    }
-
-    private long convertToLong(byte[] bts) {
-        if (bts == null || bts.length == 0) {
-            return 0;
-        }
-        long res = bts[0];
-        int limit = Math.min(8, bts.length);
-        for (int i = 1; i < limit; i++) {
-            res += ((long) bts[i] << 8*i);
-        }
-        return res;
-    }
-
-    private byte[] covertToBytes(long val) {
-        byte[] res = new byte[8];
-        Arrays.fill(res, (byte) 0);
-        for (int i = 0; i < 8; i++) {
-            res[i] = (byte) (val & 0xff);
-            val = val >> 8;
-        }
-        return res;
-    }
-
-    public <T extends Number> T decrementAndGet(byte[] key) {
-        return null;
-    }
-
-    public <T extends Number> T addAndGet(byte[] key, T delta) {
-        return null;
-    }
-
-    public <T extends Number> T accumulateAndGet(byte[] key, BinaryOperator<T> operator) {
-        return null;
-    }
-
-    public <T extends Number> T updateAndGet(byte[] key, UnaryOperator<T> operator) {
-        return null;
+        return addAndGet(keyByteStr, delta);
     }
 
     public String get(Api.ReadConsistency consistency, String key) {
@@ -356,5 +300,29 @@ public class SimpleDKVClient implements DKVClient {
             throw new DKVException(status, "MultiGet", new Object[]{consistency, keyByteStrs});
         }
         return multiGetRes.getKeyValuesList();
+    }
+
+    private long addAndGet(ByteString keyByteStr, long delta) {
+        ByteString expValByteStr, updatedValByteStr;
+        long updatedVal;
+        do {
+            expValByteStr = get(Api.ReadConsistency.LINEARIZABLE, keyByteStr);
+            updatedVal = convertToLong(expValByteStr) + delta;
+            updatedValByteStr = covertToBytes(updatedVal);
+        } while (!cas(keyByteStr, expValByteStr, updatedValByteStr));
+        return updatedVal;
+    }
+
+    private boolean cas(ByteString keyByteStr, ByteString expectByteStr, ByteString updateByteStr) {
+        Api.CompareAndSetRequest.Builder casReqBuilder = Api.CompareAndSetRequest.newBuilder();
+        Api.CompareAndSetRequest casReq = casReqBuilder
+                .setKey(keyByteStr).setOldValue(expectByteStr).setNewValue(updateByteStr)
+                .build();
+        Api.CompareAndSetResponse casRes = blockingStub.compareAndSet(casReq);
+        Api.Status status = casRes.getStatus();
+        if (status.getCode() != 0) {
+            throw new DKVException(status, "CompareAndSet", new Object[]{keyByteStr, expectByteStr, updateByteStr});
+        }
+        return casRes.getUpdated();
     }
 }

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
@@ -146,42 +146,51 @@ public class SimpleDKVClient implements DKVClient {
         blockingStub = DKVGrpc.newBlockingStub(channel);
     }
 
+    @Override
     public void put(String key, String value) {
         put(copyFromUtf8(key), copyFromUtf8(value));
     }
 
+    @Override
     public void put(byte[] key, byte[] value) {
         put(copyFrom(key), copyFrom(value));
     }
 
+    @Override
     public boolean compareAndSet(byte[] key, byte[] expect, byte[] update) {
         ByteString expectByteStr = expect != null ? copyFrom(expect) : EMPTY;
         return cas(copyFrom(key), expectByteStr, copyFrom(update));
     }
 
+    @Override
     public long incrementAndGet(byte[] key) {
         return addAndGet(key, 1);
     }
 
+    @Override
     public long decrementAndGet(byte[] key) {
         return addAndGet(key, -1);
     }
 
+    @Override
     public long addAndGet(byte[] key, long delta) {
         ByteString keyByteStr = copyFrom(key);
         return addAndGet(keyByteStr, delta);
     }
 
+    @Override
     public String get(Api.ReadConsistency consistency, String key) {
         ByteString value = get(consistency, copyFromUtf8(key));
         return value.toStringUtf8();
     }
 
+    @Override
     public byte[] get(Api.ReadConsistency consistency, byte[] key) {
         ByteString value = get(consistency, copyFrom(key));
         return value.toByteArray();
     }
 
+    @Override
     public KV.Strings[] multiGet(Api.ReadConsistency consistency, String[] keys) {
         LinkedList<ByteString> keyByteStrs = new LinkedList<>();
         for (String key : keys) {
@@ -196,6 +205,7 @@ public class SimpleDKVClient implements DKVClient {
         return result;
     }
 
+    @Override
     public KV.Bytes[] multiGet(Api.ReadConsistency consistency, byte[][] keys) {
         LinkedList<ByteString> keyByteStrs = new LinkedList<>();
         for (byte[] key : keys) {
@@ -210,18 +220,22 @@ public class SimpleDKVClient implements DKVClient {
         return result;
     }
 
+    @Override
     public Iterator<DKVEntry> iterate(String startKey) {
         return iterate(copyFromUtf8(startKey), EMPTY);
     }
 
+    @Override
     public Iterator<DKVEntry> iterate(byte[] startKey) {
         return iterate(copyFrom(startKey), EMPTY);
     }
 
+    @Override
     public Iterator<DKVEntry> iterate(String startKey, String keyPref) {
         return iterate(copyFromUtf8(startKey), copyFromUtf8(keyPref));
     }
 
+    @Override
     public Iterator<DKVEntry> iterate(byte[] startKey, byte[] keyPref) {
         return iterate(copyFrom(startKey), copyFrom(keyPref));
     }

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/Utils.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/Utils.java
@@ -1,7 +1,10 @@
 package org.dkv.client;
 
+import com.google.protobuf.ByteString;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
 
 import static java.lang.String.format;
 
@@ -28,5 +31,20 @@ public class Utils {
         if (!condition) {
             throwf(excClass, msg, keys);
         }
+    }
+
+    static long convertToLong(byte[] bts) {
+        if (bts.length == 0) return 0;
+        return ByteBuffer.wrap(bts).getLong();
+    }
+
+    static long convertToLong(ByteString byteStr) {
+        if (byteStr.isEmpty()) return 0;
+        return byteStr.asReadOnlyByteBuffer().getLong();
+    }
+
+    static ByteString covertToBytes(long val) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(8).putLong(val);
+        return ByteString.copyFrom(byteBuffer.array());
     }
 }

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
@@ -5,14 +5,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.dkv.client.Utils.convertToLong;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SimpleDKVClientTest {
 

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
@@ -29,6 +29,17 @@ public class SimpleDKVClientTest {
     }
 
     @Test
+    public void shouldPerformIncrementAndGet() {
+        String key = "myCtr" + System.currentTimeMillis();
+        long val = dkvCli.incrementAndGet(key.getBytes());
+        assertEquals(1, val);
+        val = dkvCli.incrementAndGet(key.getBytes());
+        assertEquals(2, val);
+        val = dkvCli.incrementAndGet(key.getBytes());
+        assertEquals(3, val);
+    }
+
+    @Test
     public void shouldPerformMultiGet() {
         String keyPref = "K_", valPref = "V_";
         String[] keys = put(10, keyPref, valPref);

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
@@ -5,10 +5,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.*;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
+import static org.dkv.client.Utils.convertToLong;
+import static org.junit.Assert.*;
 
 public class SimpleDKVClientTest {
 
@@ -29,14 +33,66 @@ public class SimpleDKVClientTest {
     }
 
     @Test
-    public void shouldPerformIncrementAndGet() {
-        String key = "myCtr" + System.currentTimeMillis();
-        long val = dkvCli.incrementAndGet(key.getBytes());
-        assertEquals(1, val);
-        val = dkvCli.incrementAndGet(key.getBytes());
-        assertEquals(2, val);
-        val = dkvCli.incrementAndGet(key.getBytes());
-        assertEquals(3, val);
+    public void shouldPerformAtomicKeyCreation() throws InterruptedException {
+        byte[] key = ("myCtr" + System.currentTimeMillis()).getBytes();
+        int numThrs = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(numThrs);
+        Map<Integer, Boolean> results = new ConcurrentHashMap<>(numThrs);
+        for (int i = 1; i <= numThrs; i++) {
+            final int id = i;
+            pool.execute(() -> {
+                boolean res = dkvCli.compareAndSet(key, null, "hello".getBytes());
+                results.put(id, res);
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        int numSucc = 0, numFail = 0;
+        for (Boolean value : results.values()) {
+            if (value) numSucc++;
+            if (!value) numFail++;
+        }
+        assertEquals(1, numSucc);
+        assertEquals(numThrs - 1, numFail);
+    }
+
+    @Test
+    public void shouldPerformAtomicAddition() throws InterruptedException {
+        byte[] key = ("myCtr" + System.currentTimeMillis()).getBytes();
+        int numThrs = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(numThrs);
+        for (int i = 1; i <= numThrs; i++) {
+            final int id = i;
+            pool.execute(() -> {
+                int delta = (id & 1) == 1 ? 1 : -1;
+                dkvCli.addAndGet(key, delta);
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        byte[] actualBts = dkvCli.get(Api.ReadConsistency.LINEARIZABLE, key);
+        assertEquals(0L, convertToLong(actualBts));
+    }
+
+    @Test
+    public void shouldPerformAtomicIncrDecr() throws InterruptedException {
+        byte[] key = ("myCtr" + System.currentTimeMillis()).getBytes();
+        int numThrs = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(numThrs);
+        for (int i = 1; i <= numThrs; i++) {
+            final int id = i;
+            pool.execute(() -> {
+                if ((id & 1) == 1) {
+                    dkvCli.incrementAndGet(key);
+                } else {
+                    dkvCli.decrementAndGet(key);
+                }
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        byte[] actualBts = dkvCli.get(Api.ReadConsistency.LINEARIZABLE, key);
+        assertEquals(0L, convertToLong(actualBts));
     }
 
     @Test

--- a/internal/master/ds_service_test.go
+++ b/internal/master/ds_service_test.go
@@ -89,16 +89,16 @@ func testDistAtomicKeyCreation(t *testing.T) {
 
 	// verify atomic key creation under contention
 	// against all cluster nodes
-	cliId := 0
+	cliID := 0
 	for i := 0; i < numThrs; i++ {
 		wg.Add(1)
 		// cycle through the next cluster node client
-		cliId = 1 + (cliId+1)%clusterSize
+		cliID = 1 + (cliID+1)%clusterSize
 		go func(id, clId int) {
 			defer wg.Done()
 			res, err := dkvClis[clId].CompareAndSet(casKey, nil, casVal)
 			freqs.Store(id, res && err == nil)
-		}(i, cliId)
+		}(i, cliID)
 	}
 	wg.Wait()
 
@@ -133,11 +133,11 @@ func testDistAtomicIncrDecr(t *testing.T) {
 
 	// even threads increment, odd threads decrement
 	// a given key, all this done across cluster nodes
-	cliId := 0
+	cliID := 0
 	for i := 0; i < numThrs; i++ {
 		wg.Add(1)
 		// cycle through the next cluster node client
-		cliId = 1 + (cliId+1)%clusterSize
+		cliID = 1 + (cliID+1)%clusterSize
 		go func(id, clId int) {
 			defer wg.Done()
 			delta := byte(0)
@@ -156,7 +156,7 @@ func testDistAtomicIncrDecr(t *testing.T) {
 					break
 				}
 			}
-		}(i, cliId)
+		}(i, cliID)
 	}
 	wg.Wait()
 

--- a/internal/storage/badger/store.go
+++ b/internal/storage/badger/store.go
@@ -231,7 +231,7 @@ func (bdb *badgerDB) CompareAndSet(key, expect, update []byte) (bool, error) {
 	exist, err := casTrxn.Get(key)
 	switch {
 	case err == badger.ErrKeyNotFound:
-		if expect != nil {
+		if expect != nil && len(expect) > 0 {
 			return false, nil
 		}
 	case err != nil:
@@ -249,6 +249,9 @@ func (bdb *badgerDB) CompareAndSet(key, expect, update []byte) (bool, error) {
 		return false, err
 	}
 	err = casTrxn.Commit()
+	if err == badger.ErrConflict {
+		return false, nil
+	}
 	return err == nil, err
 }
 

--- a/internal/storage/rocksdb/store.go
+++ b/internal/storage/rocksdb/store.go
@@ -204,7 +204,7 @@ func (rdb *rocksDB) CompareAndSet(key, expect, update []byte) (bool, error) {
 	defer exist.Free()
 
 	existVal := exist.Data()
-	if expect == nil {
+	if expect == nil || len(expect) == 0 {
 		if len(existVal) > 0 {
 			return false, nil
 		}
@@ -219,6 +219,9 @@ func (rdb *rocksDB) CompareAndSet(key, expect, update []byte) (bool, error) {
 		return false, err
 	}
 	err = txn.Commit()
+	if err != nil && strings.HasSuffix(err.Error(), "Resource busy: ") {
+		return false, nil
+	}
 	return err == nil, err
 }
 


### PR DESCRIPTION
This PR builds the necessary bindings into the Java client for working with DKV CAS operations. New API additions:

1. `boolean compareAndSet(byte[] key, byte[] expect, byte[] update);`
2. `long incrementAndGet(byte[] key);`
3. `long decrementAndGet(byte[] key);`
4. `long addAndGet(byte[] key, long delta);`

I also had to improve the error handling logic on DKV storage layer as part of this PR. Specifically, for transaction commit errors that are related to either `Resource Busy` or `Transaction Conflict` kind of failures, we no longer return this as an **error** to the user as they occur mainly because of contention. Any other kind of failure is returned as is.
