### PR TITLE
Metrics inside Java client

### DIFF
--- a/clients/java/dkv-client/pom.xml
+++ b/clients/java/dkv-client/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>zero-allocation-hashing</artifactId>
             <version>0.11</version>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>4.1.9</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/clients/java/dkv-client/pom.xml
+++ b/clients/java/dkv-client/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>metrics-core</artifactId>
             <version>4.1.9</version>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+            <version>4.1.9</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -89,6 +94,35 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>start_dkv</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.basedir}/src/test/resources/start_dkv.sh</executable>
+                            <workingDirectory>${project.basedir}/../../../</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop_dkv</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.basedir}/src/test/resources/stop_dkv.sh</executable>
+                            <workingDirectory>${project.basedir}/../../../</workingDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/DKVNodeSet.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/DKVNodeSet.java
@@ -1,8 +1,8 @@
 package org.dkv.client;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.util.Collections.unmodifiableSet;
 import static org.dkv.client.Utils.checkf;
 
 /**
@@ -18,14 +18,15 @@ import static org.dkv.client.Utils.checkf;
  */
 public class DKVNodeSet {
     private final String name;
-    private final Set<DKVNode> nodes;
+    private final DKVNode[] nodes;
+    private final AtomicInteger idx = new AtomicInteger(0);
 
     public DKVNodeSet(String name, Set<DKVNode> nodes) {
         checkf(name != null && !name.trim().isEmpty(), IllegalArgumentException.class, "DKV node set name must be given");
         checkf(nodes != null && !nodes.isEmpty(), IllegalArgumentException.class, "DKV nodes must be given");
 
         //noinspection ConstantConditions
-        this.nodes = unmodifiableSet(nodes);
+        this.nodes = nodes.toArray(new DKVNode[0]);
         this.name = name;
     }
 
@@ -33,8 +34,14 @@ public class DKVNodeSet {
         return name;
     }
 
-    public Iterable<DKVNode> getNodes() {
+    public DKVNode[] getNodes() {
         return nodes;
+    }
+
+    public DKVNode getNextNode() {
+        if (nodes == null) throw new IllegalStateException("this DKVNodeSet instance is not initialized");
+        int nextIdx = idx.getAndUpdate(id -> (id + 1) % nodes.length);
+        return nodes[nextIdx];
     }
 
     // intended for deserialization
@@ -42,5 +49,9 @@ public class DKVNodeSet {
     private DKVNodeSet() {
         this.name = null;
         this.nodes = null;
+    }
+
+    public int getNumNodes() {
+        return nodes != null ? nodes.length : 0;
     }
 }

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -239,7 +239,7 @@ public class ShardedDKVClient implements DKVClient {
 
         SimpleDKVClient getDKVClient(DKVShard dkvShard, DKVNodeType... nodeTypes) {
             DKVNodeSet nodeSet = dkvShard.getNodesByType(nodeTypes);
-            DKVNode dkvNode = Iterables.get(nodeSet.getNodes(), 0);
+            DKVNode dkvNode = nodeSet.getNextNode();
             return internalPool.get(new Key(dkvNode, nodeSet.getName()));
         }
 

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/ShardedDKVClient.java
@@ -211,10 +211,12 @@ public class ShardedDKVClient implements DKVClient {
         private static class Key {
             private final DKVNode dkvNode;
             private final String authority;
+            private final String shardName;
 
-            private Key(DKVNode dkvNode, String authority) {
+            private Key(DKVNode dkvNode, String authority, String shardName) {
                 this.dkvNode = dkvNode;
                 this.authority = authority;
+                this.shardName = shardName;
             }
 
             @Override
@@ -240,7 +242,7 @@ public class ShardedDKVClient implements DKVClient {
         SimpleDKVClient getDKVClient(DKVShard dkvShard, DKVNodeType... nodeTypes) {
             DKVNodeSet nodeSet = dkvShard.getNodesByType(nodeTypes);
             DKVNode dkvNode = nodeSet.getNextNode();
-            return internalPool.get(new Key(dkvNode, nodeSet.getName()));
+            return internalPool.get(new Key(dkvNode, nodeSet.getName(), dkvShard.getName()));
         }
 
         @Override
@@ -257,7 +259,7 @@ public class ShardedDKVClient implements DKVClient {
 
         @Override
         public SimpleDKVClient load(ShardedDKVClient.DKVClientPool.Key key) {
-            return new SimpleDKVClient(key.dkvNode.getHost(), key.dkvNode.getPort(), key.authority);
+            return new SimpleDKVClient(key.dkvNode.getHost(), key.dkvNode.getPort(), key.authority, key.shardName);
         }
 
         @Override

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/SimpleDKVClient.java
@@ -1,14 +1,18 @@
 package org.dkv.client;
 
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
 import com.google.protobuf.ByteString;
 import dkv.serverpb.Api;
 import dkv.serverpb.DKVGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import org.dkv.client.metrics.MetricsInterceptor;
 
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.protobuf.ByteString.*;
 import static org.dkv.client.Utils.convertToLong;
@@ -28,7 +32,10 @@ import static org.dkv.client.Utils.covertToBytes;
  * @see DKVException
  */
 public class SimpleDKVClient implements DKVClient {
+    private static final MetricRegistry metrics = new MetricRegistry();
     private final DKVGrpc.DKVBlockingStub blockingStub;
+    private final ManagedChannel channel;
+    private final JmxReporter reporter;
 
     /**
      * Creates an instance with the underlying GRPC conduit to the DKV database
@@ -38,22 +45,13 @@ public class SimpleDKVClient implements DKVClient {
      *
      * @param dkvHost host on which DKV database is running
      * @param dkvPort port the DKV database is listening on
+     * @param metricPrefix prefix for the published metrics
      * @throws IllegalArgumentException if the specified <tt>dkvHost</tt> or <tt>dkvPort</tt>
      * is invalid
      * @throws RuntimeException in case of any connection failures
      */
-    public SimpleDKVClient(String dkvHost, int dkvPort) {
-        if (dkvHost == null || dkvHost.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid DKV hostname must be provided");
-        }
-
-        if (dkvPort <= 0) {
-            throw new IllegalArgumentException("Valid DKV port must be provided");
-        }
-
-        ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(dkvHost, dkvPort).usePlaintext();
-        ManagedChannel channel = channelBuilder.build();
-        blockingStub = DKVGrpc.newBlockingStub(channel);
+    public SimpleDKVClient(String dkvHost, int dkvPort, String metricPrefix) {
+        this(getManagedChannelBuilder(dkvHost, dkvPort), metricPrefix);
     }
 
     /**
@@ -71,26 +69,13 @@ public class SimpleDKVClient implements DKVClient {
      * @param dkvHost host on which DKV database is running
      * @param dkvPort port the DKV database is listening on
      * @param authority value to be sent inside the HTTP/2 authority header
+     * @param metricPrefix prefix for the published metrics
      * @throws IllegalArgumentException if the specified <tt>dkvHost</tt> or <tt>dkvPort</tt>
      * is invalid
      * @throws RuntimeException in case of any connection failures
      */
-    public SimpleDKVClient(String dkvHost, int dkvPort, String authority) {
-        if (dkvHost == null || dkvHost.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid DKV hostname must be provided");
-        }
-
-        if (authority == null || authority.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid authority must be provided");
-        }
-
-        if (dkvPort <= 0) {
-            throw new IllegalArgumentException("Valid DKV port must be provided");
-        }
-
-        ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(dkvHost, dkvPort).usePlaintext().overrideAuthority(authority);
-        ManagedChannel channel = channelBuilder.build();
-        blockingStub = DKVGrpc.newBlockingStub(channel);
+    public SimpleDKVClient(String dkvHost, int dkvPort, String authority, String metricPrefix) {
+        this(getManagedChannelBuilder(dkvHost, dkvPort, authority), metricPrefix);
     }
 
     /**
@@ -100,18 +85,13 @@ public class SimpleDKVClient implements DKVClient {
      * implementations will support additional options for securing these exchanges.
      *
      * @param dkvTarget location (in the form host:port) at which DKV database is running
+     * @param metricPrefix prefix for the published metrics
      * @throws IllegalArgumentException if the specified <tt>dkvHost</tt> or <tt>dkvPort</tt>
      * is invalid
      * @throws RuntimeException in case of any connection failures
      */
-    public SimpleDKVClient(String dkvTarget) {
-        if (dkvTarget == null || dkvTarget.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid DKV hostname must be provided");
-        }
-
-        ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget(dkvTarget).usePlaintext();
-        ManagedChannel channel = channelBuilder.build();
-        blockingStub = DKVGrpc.newBlockingStub(channel);
+    public SimpleDKVClient(String dkvTarget, String metricPrefix) {
+        this(getManagedChannelBuilder(dkvTarget), metricPrefix);
     }
 
     /**
@@ -128,22 +108,13 @@ public class SimpleDKVClient implements DKVClient {
      *
      * @param dkvTarget location (in the form host:port) at which DKV database is running
      * @param authority value to be sent inside the HTTP/2 authority header
+     * @param metricPrefix prefix for the published metrics
      * @throws IllegalArgumentException if the specified <tt>dkvHost</tt> or <tt>dkvPort</tt>
      * is invalid
      * @throws RuntimeException in case of any connection failures
      */
-    public SimpleDKVClient(String dkvTarget, String authority) {
-        if (dkvTarget == null || dkvTarget.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid DKV target (host:port) must be provided");
-        }
-
-        if (authority == null || authority.trim().length() == 0) {
-            throw new IllegalArgumentException("Valid authority must be provided");
-        }
-
-        ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget(dkvTarget).usePlaintext().overrideAuthority(authority);
-        ManagedChannel channel = channelBuilder.build();
-        blockingStub = DKVGrpc.newBlockingStub(channel);
+    public SimpleDKVClient(String dkvTarget, String authority, String metricPrefix) {
+        this(getManagedChannelBuilder(dkvTarget, authority), metricPrefix);
     }
 
     @Override
@@ -242,7 +213,19 @@ public class SimpleDKVClient implements DKVClient {
 
     @Override
     public void close() {
-        ((ManagedChannel) blockingStub.getChannel()).shutdownNow();
+        channel.shutdownNow();
+        reporter.stop();
+    }
+
+    private SimpleDKVClient(ManagedChannelBuilder<?> channelBuilder, String metricPrefix) {
+        this.reporter = JmxReporter.forRegistry(metrics)
+                .inDomain(metricPrefix)
+                .convertRatesTo(TimeUnit.MILLISECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build();
+        this.reporter.start();
+        this.channel = channelBuilder.build();
+        this.blockingStub = DKVGrpc.newBlockingStub(channel).withInterceptors(new MetricsInterceptor(metrics));
     }
 
     private Iterator<DKVEntry> iterate(ByteString startKey, ByteString keyPref) {
@@ -339,4 +322,36 @@ public class SimpleDKVClient implements DKVClient {
         }
         return casRes.getUpdated();
     }
+
+    private static ManagedChannelBuilder<?> getManagedChannelBuilder(String dkvHost, int dkvPort) {
+        if (dkvHost == null || dkvHost.trim().length() == 0) {
+            throw new IllegalArgumentException("Valid DKV hostname must be provided");
+        }
+        if (dkvPort <= 0) {
+            throw new IllegalArgumentException("Valid DKV port must be provided");
+        }
+        return ManagedChannelBuilder.forAddress(dkvHost, dkvPort).usePlaintext();
+    }
+
+    private static ManagedChannelBuilder<?> getManagedChannelBuilder(String dkvHost, int dkvPort, String authority) {
+        if (authority == null || authority.trim().length() == 0) {
+            throw new IllegalArgumentException("Valid authority must be provided");
+        }
+        return getManagedChannelBuilder(dkvHost, dkvPort).overrideAuthority(authority);
+    }
+
+    private static ManagedChannelBuilder<?> getManagedChannelBuilder(String dkvTarget) {
+        if (dkvTarget == null || dkvTarget.trim().length() == 0) {
+            throw new IllegalArgumentException("Valid DKV hostname must be provided");
+        }
+        return ManagedChannelBuilder.forTarget(dkvTarget).usePlaintext();
+    }
+
+    private static ManagedChannelBuilder<?> getManagedChannelBuilder(String dkvTarget, String authority) {
+        if (authority == null || authority.trim().length() == 0) {
+            throw new IllegalArgumentException("Valid authority must be provided");
+        }
+        return getManagedChannelBuilder(dkvTarget).overrideAuthority(authority);
+    }
+
 }

--- a/clients/java/dkv-client/src/main/java/org/dkv/client/metrics/MetricsInterceptor.java
+++ b/clients/java/dkv-client/src/main/java/org/dkv/client/metrics/MetricsInterceptor.java
@@ -1,0 +1,68 @@
+package org.dkv.client.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import io.grpc.*;
+
+public class MetricsInterceptor implements ClientInterceptor {
+    private final MetricRegistry metrics;
+
+    public MetricsInterceptor(MetricRegistry metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,
+                                                               CallOptions callOptions, Channel channel) {
+        String grpcName = methodDescriptor.getFullMethodName().replace('/', '.');
+        Meter requests = metrics.meter(grpcName + ".requests");
+        Meter errors = metrics.meter(grpcName + ".errors");
+        Timer timer = metrics.timer(grpcName + ".latencies");
+        return new MonitoringClientCall<>(
+                channel.newCall(methodDescriptor, callOptions), requests, errors, timer);
+    }
+
+    private static class MonitoringClientCall<ReqT, RespT> extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
+        private final Meter requests;
+        private final Meter errors;
+        private final Timer timer;
+
+        public MonitoringClientCall(ClientCall<ReqT, RespT> clientCall, Meter requests, Meter errors, Timer timer) {
+            super(clientCall);
+            this.requests = requests;
+            this.errors = errors;
+            this.timer = timer;
+        }
+
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+            requests.mark();
+            super.start(new MonitoringClientCallListener<>(responseListener, errors, timer.time()), headers);
+        }
+    }
+
+    private static class MonitoringClientCallListener<RespT> extends ForwardingClientCallListener<RespT> {
+        private final ClientCall.Listener<RespT> delegate;
+        private final Meter errors;
+        private final Timer.Context responseTimer;
+
+        public MonitoringClientCallListener(ClientCall.Listener<RespT> delegate, Meter errors, Timer.Context responseTimer) {
+            this.delegate = delegate;
+            this.errors = errors;
+            this.responseTimer = responseTimer;
+        }
+
+        @Override
+        protected ClientCall.Listener<RespT> delegate() {
+            return delegate;
+        }
+
+        @Override
+        public void onClose(Status status, Metadata trailers) {
+            responseTimer.stop();
+            if (!status.isOk()) errors.mark();
+            super.onClose(status, trailers);
+        }
+    }
+}

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/ShardConfigurationTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/ShardConfigurationTest.java
@@ -19,22 +19,24 @@ public class ShardConfigurationTest {
         assertNotNull(configStream);
         Gson gson = new Gson();
         ShardConfiguration shardConf = gson.fromJson(new InputStreamReader(configStream), ShardConfiguration.class);
-        assertEquals(3, shardConf.getNumShards());
+        assertEquals(1, shardConf.getNumShards());
         for (int i = 0; i < shardConf.getNumShards(); i++) {
             DKVShard dkvShard = shardConf.getShardAtIndex(i);
             assertEquals("shard"+i, dkvShard.getName());
 
-            DKVNodeSet readNodes = dkvShard.getNodesByType(DKVNodeType.MASTER);
-            assertEquals(1, size(readNodes.getNodes()));
-            DKVNode dkvNode = getLast(readNodes.getNodes());
+            DKVNodeSet master = dkvShard.getNodesByType(DKVNodeType.MASTER);
+            assertEquals(1, master.getNumNodes());
+            DKVNode dkvNode = master.getNodes()[0];
             assertEquals("127.0.0.1", dkvNode.getHost());
-            assertEquals(8081+i, dkvNode.getPort());
+            assertEquals(8080, dkvNode.getPort());
 
-            DKVNodeSet writeNodes = dkvShard.getNodesByType(DKVNodeType.SLAVE);
-            assertEquals(1, size(writeNodes.getNodes()));
-            dkvNode = getLast(writeNodes.getNodes());
-            assertEquals("127.0.0.1", dkvNode.getHost());
-            assertEquals(8081+i, dkvNode.getPort());
+            DKVNodeSet slaves = dkvShard.getNodesByType(DKVNodeType.SLAVE);
+            assertEquals(4, slaves.getNumNodes());
+
+            for (int j = 0; j < slaves.getNumNodes(); j++) {
+                assertEquals("127.0.0.1", slaves.getNodes()[j].getHost());
+                assertEquals(8091 + j, slaves.getNodes()[j].getPort());
+            }
         }
     }
 }

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/ShardConfigurationTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/ShardConfigurationTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import static com.google.common.collect.Iterables.getLast;
-import static com.google.common.collect.Iterables.size;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/ShardedDKVClientTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/ShardedDKVClientTest.java
@@ -25,7 +25,8 @@ public class ShardedDKVClientTest {
 
     @Before
     public void setup() {
-        ShardConfiguration shardConf = loadShardConfig("/local_dkv_config.json");
+//        ShardConfiguration shardConf = loadShardConfig("/local_dkv_config.json");
+        ShardConfiguration shardConf = loadShardConfig("/three_shard_config.json");
 //        ShardConfiguration shardConf = loadShardConfig("/local_dkv_config_via_envoy.json");
 //        ShardConfiguration shardConf = loadShardConfig("/single_local_dkv_config.json");
         dkvClient = new ShardedDKVClient(new KeyHashBasedShardProvider(shardConf));
@@ -58,6 +59,7 @@ public class ShardedDKVClientTest {
 
         try {
             dkvClient.multiGet(LINEARIZABLE, keys);
+//            fail("expecting an exception");
         } catch (Exception e) {
             assertTrue(e instanceof UnsupportedOperationException);
         }

--- a/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
+++ b/clients/java/dkv-client/src/test/java/org/dkv/client/SimpleDKVClientTest.java
@@ -24,7 +24,7 @@ public class SimpleDKVClientTest {
 
     @Before
     public void setUp() {
-        dkvCli = new SimpleDKVClient(DKV_TARGET);
+        dkvCli = new SimpleDKVClient(DKV_TARGET, null);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class SimpleDKVClientTest {
         put(numKeys, keyPref2, valPref2);
         put(numKeys, keyPref3, valPref3);
         String startKey = format("%s%d", keyPref2, startIdx);
-        Iterator<DKVEntry> iterRes = new SimpleDKVClient(DKV_TARGET).iterate(startKey, keyPref2);
+        Iterator<DKVEntry> iterRes = new SimpleDKVClient(DKV_TARGET, null).iterate(startKey, keyPref2);
         while (iterRes.hasNext()) {
             DKVEntry entry = iterRes.next();
             entry.checkStatus();
@@ -128,7 +128,7 @@ public class SimpleDKVClientTest {
 
         startIdx = 1;
         startKey = format("%s%d", keyPref1, startIdx);
-        iterRes = new SimpleDKVClient(DKV_TARGET).iterate(startKey);
+        iterRes = new SimpleDKVClient(DKV_TARGET, null).iterate(startKey);
         while (iterRes.hasNext()) {
             DKVEntry entry = iterRes.next();
             entry.checkStatus();

--- a/clients/java/dkv-client/src/test/resources/shard_config.json
+++ b/clients/java/dkv-client/src/test/resources/shard_config.json
@@ -8,7 +8,19 @@
           "nodes": [
             {
               "host": "127.0.0.1",
-              "port": 8081
+              "port": 8091
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8092
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8093
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8094
             }
           ]
         },
@@ -17,53 +29,7 @@
           "nodes": [
             {
               "host": "127.0.0.1",
-              "port": 8081
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "shard1",
-      "topology": {
-        "SLAVE": {
-          "name": "slaves",
-          "nodes": [
-            {
-              "host": "127.0.0.1",
-              "port": 8082
-            }
-          ]
-        },
-        "MASTER": {
-          "name": "masters",
-          "nodes": [
-            {
-              "host": "127.0.0.1",
-              "port": 8082
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "shard2",
-      "topology": {
-        "SLAVE": {
-          "name": "slaves",
-          "nodes": [
-            {
-              "host": "127.0.0.1",
-              "port": 8083
-            }
-          ]
-        },
-        "MASTER": {
-          "name": "masters",
-          "nodes": [
-            {
-              "host": "127.0.0.1",
-              "port": 8083
+              "port": 8080
             }
           ]
         }

--- a/clients/java/dkv-client/src/test/resources/start_dkv.sh
+++ b/clients/java/dkv-client/src/test/resources/start_dkv.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+DKV_EXEC="nohup ./bin/dkvsrv"
+
+$DKV_EXEC -dbRole master -dbListenAddr 127.0.0.1:7080 -dbFolder /tmp/dkvsrv/s0 > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:7091 -replMasterAddr 127.0.0.1:7080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:7092 -replMasterAddr 127.0.0.1:7080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:7093 -replMasterAddr 127.0.0.1:7080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:7094 -replMasterAddr 127.0.0.1:7080 -replPollInterval 100ms > /dev/null 2>&1 &
+
+$DKV_EXEC -dbRole master -dbListenAddr 127.0.0.1:8080 -dbFolder /tmp/dkvsrv/s1 > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:8091 -replMasterAddr 127.0.0.1:8080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:8092 -replMasterAddr 127.0.0.1:8080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:8093 -replMasterAddr 127.0.0.1:8080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:8094 -replMasterAddr 127.0.0.1:8080 -replPollInterval 100ms > /dev/null 2>&1 &
+
+$DKV_EXEC -dbRole master -dbListenAddr 127.0.0.1:9080 -dbFolder /tmp/dkvsrv/s2 > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:9091 -replMasterAddr 127.0.0.1:9080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:9092 -replMasterAddr 127.0.0.1:9080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:9093 -replMasterAddr 127.0.0.1:9080 -replPollInterval 100ms > /dev/null 2>&1 &
+$DKV_EXEC -dbDiskless -dbEngine badger -dbRole slave -dbListenAddr 127.0.0.1:9094 -replMasterAddr 127.0.0.1:9080 -replPollInterval 100ms > /dev/null 2>&1 &

--- a/clients/java/dkv-client/src/test/resources/stop_dkv.sh
+++ b/clients/java/dkv-client/src/test/resources/stop_dkv.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pkill -9 "dkvsrv"

--- a/clients/java/dkv-client/src/test/resources/three_shard_config.json
+++ b/clients/java/dkv-client/src/test/resources/three_shard_config.json
@@ -1,0 +1,109 @@
+{
+  "dkvShards": [
+    {
+      "name": "shard0",
+      "topology": {
+        "SLAVE": {
+          "name": "slaves",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 7091
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 7092
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 7093
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 7094
+            }
+          ]
+        },
+        "MASTER": {
+          "name": "masters",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 7080
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "shard1",
+      "topology": {
+        "SLAVE": {
+          "name": "slaves",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 8091
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8092
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8093
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 8094
+            }
+          ]
+        },
+        "MASTER": {
+          "name": "masters",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 8080
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "shard2",
+      "topology": {
+        "SLAVE": {
+          "name": "slaves",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 9091
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 9092
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 9093
+            },
+            {
+              "host": "127.0.0.1",
+              "port": 9094
+            }
+          ]
+        },
+        "MASTER": {
+          "name": "masters",
+          "nodes": [
+            {
+              "host": "127.0.0.1",
+              "port": 9080
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PR that emits metrics against all interaction with the DKV services. Here are the changes:

1. Fixed a bug where the internal pool was always selecting the first DKV node for a given shard. Although this is alright for Envoy based setups, but in other cases it leads to hotspotting of a single DKV node.
2. Integration with Dropwizard metrics for extracting GRPC call level stats using a `ClientInterceptor`.
3. Support for shard level metrics by setting the reporting domain to the appropriate shard.
4. Addressed a minor tech debt in our builds - starting and stopping DKV servers for tests.

