### PR TITLE
Use rocksdb checkpoint for snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -fsSL https://github.com/facebook/rocksdb/archive/v6.5.3.tar.gz | tar x
     && cd rocksdb-6.5.3 && make install
 
 # Install GoLang
-RUN curl -fsSL https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar xz \
+RUN curl -fsSL https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz | tar xz \
     && chown -R root:root ./go && mv ./go /usr/local
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DKV is a distributed key value store server written in [Go](https://golang.org).
 <img src="https://github.com/flipkart-incubator/dkv/raw/master/docs/design.png">
 
 ## Dependencies
-- Go version 1.13+
+- Go version 1.16+
 - [RocksDB](https://github.com/facebook/rocksdb) v6.5.3 as a storage engine
 - [GoRocksDB](https://github.com/tecbot/gorocksdb) provides the CGo bindings with RocksDB
 - [Badger](https://github.com/dgraph-io/badger) v1.6 as a storage engine

--- a/internal/storage/rocksdb/store_test.go
+++ b/internal/storage/rocksdb/store_test.go
@@ -664,6 +664,7 @@ func TestGetPutSnapshot(t *testing.T) {
 			getKeys(t, numTrxns, keyPrefix1, valPrefix1)
 			getKeys(t, numTrxns, keyPrefix1T, valPrefix1T)
 			//getKeys(t, numTrxns, keyPrefix2, valPrefix2)
+			noKeys(t, numTrxns, keyPrefix2)
 		}
 	}
 }
@@ -687,7 +688,8 @@ func TestGetPutSnapshotTTLOnly(t *testing.T) {
 			t.Fatal(err)
 		} else {
 			getKeys(t, numTrxns, keyPrefix1T, valPrefix1T)
-			getKeys(t, numTrxns, keyPrefix2, valPrefix2)
+			//getKeys(t, numTrxns, keyPrefix2, valPrefix2)
+			noKeys(t, numTrxns, keyPrefix2)
 		}
 	}
 }

--- a/internal/storage/rocksdb/store_test.go
+++ b/internal/storage/rocksdb/store_test.go
@@ -663,7 +663,7 @@ func TestGetPutSnapshot(t *testing.T) {
 		} else {
 			getKeys(t, numTrxns, keyPrefix1, valPrefix1)
 			getKeys(t, numTrxns, keyPrefix1T, valPrefix1T)
-			getKeys(t, numTrxns, keyPrefix2, valPrefix2)
+			//getKeys(t, numTrxns, keyPrefix2, valPrefix2)
 		}
 	}
 }


### PR DESCRIPTION
Impements #87 

Massive improvement in snapshot time for rocksdb

![image](https://user-images.githubusercontent.com/709368/131661485-0052afb8-ecb9-4d72-a494-1598ca0da3b5.png)

Note: Behavior change ( any commits before a snapshot being applied would be lost as the db would be restored with the snapshot. This will also take care of consistent change number when snap is applied on a rocksdb)

