### PR TITLE
Bump rocksdb to 6.22.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           build-args: |
             BASE=ubuntu:18.04
+            CI=true
       - name: Run tests
         run: |
           docker run -i localhost:5000/${{ github.repository_owner }}/dkv:latest bash -c "cd /code && GOOS=linux GOARCH=amd64 make test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN curl -fsSL https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.
     && cd zstd-1.4.4 && make install
 
 # Install RocksDB v6.5.3
-RUN curl -fsSL https://github.com/facebook/rocksdb/archive/v6.5.3.tar.gz | tar xz \
-    && cd rocksdb-6.5.3 && make install
+RUN curl -fsSL https://github.com/facebook/rocksdb/archive/v6.22.1.tar.gz | tar xz \
+    && cd rocksdb-6.22.1 && make install
 
 # Install GoLang
 RUN curl -fsSL https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz | tar xz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ RUN curl -fsSL -O https://github.com/protocolbuffers/protobuf/releases/download/
     && rm protoc-3.15.8-linux-x86_64.zip
 ENV PATH="/usr/local/protoc/bin:${PATH}"
 
-# Install DKV
-RUN git clone https://github.com/flipkart-incubator/dkv.git \
+# Install DKV (Skipped for CI Pipelines)
+ARG CI
+RUN if [ -z "$CI" ] ; then git clone --depth=1 https://github.com/flipkart-incubator/dkv.git \
     && cd dkv && GOOS=linux GOARCH=amd64 make build \
-    && mv ./bin /usr/local/dkv && chown -R root:root /usr/local/dkv
+    && mv ./bin /usr/local/dkv && chown -R root:root /usr/local/dkv; fi
+
 ENV PATH="/usr/local/dkv:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DKV is a distributed key value store server written in [Go](https://golang.org).
 
 ## Dependencies
 - Go version 1.16+
-- [RocksDB](https://github.com/facebook/rocksdb) v6.5.3 as a storage engine
+- [RocksDB](https://github.com/facebook/rocksdb) v6.22.1 as a storage engine
 - [GoRocksDB](https://github.com/tecbot/gorocksdb) provides the CGo bindings with RocksDB
 - [Badger](https://github.com/dgraph-io/badger) v1.6 as a storage engine
 - [Nexus](https://github.com/flipkart-incubator/nexus) for sync replication over [Raft](https://raft.github.io/) consensus
@@ -118,12 +118,12 @@ $ ./bin/dkvsrv \
     -db-folder <folder_path> \
     -listen-addr <host:port> \
     -role master \
-    -nexus-node-url http://<host:port> \ #optional when running on separete nodes.
+    -nexus-node-url http://<host:port> \ #optional when running on separate nodes.
     -nexus-cluster-url <cluster_url>
 ```
 
 All these 3 DKV instances form a database cluster each listening on separate ports for
-Nexus & client communications. One can now construct the value for `nexusClusterUrl` param
+Nexus & client communications. One can now construct the value for `nexus-cluster-url` param
 in the above command using this example setup below:
 
 |NexusNodeId|Hostname|NexusPort|
@@ -132,7 +132,7 @@ in the above command using this example setup below:
 |2|dkv.az2|9020|
 |3|dkv.az3|9020|
 
-Then the value for `nexusClusterUrl` must be:
+Then the value for `nexus-cluster-url` must be:
 ```bash
 "http://dkv.az1:9020,http://dkv.az2:9020,http://dkv.az3:9020"
 ```
@@ -253,7 +253,7 @@ $ ./bin/dkvsrv \
 Subsequently, any mutations performed on the master node's keyspace using `dkvctl`
 will be applied automatically onto the slave node's keyspace. By default, a given
 slave node polls for changes from its master node once every _5 seconds_. This can
-be changed through the `replPollInterval` flag while launching the slave node.
+be changed through the `repl-poll-interval` flag while launching the slave node.
 
 Note that only **rocksdb** engine is supported on the DKV master node while the slave
 node can be launched with either *rocksdb* or *badger* storage engines.
@@ -262,7 +262,7 @@ node can be launched with either *rocksdb* or *badger* storage engines.
 
 For slave nodes using the Badger storage engine, we also support an in-memory mode
 where the entire dataset is stored in RAM without any writes to disk whatsoever.
-This can be achieved by using the `-dbDiskless` option during launch as shown here.
+This can be achieved by using the `-diskless` option during launch as shown here.
 
 ```bash
 $ ./bin/dkvsrv \

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
-	github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724
+	github.com/flipkart-incubator/gorocksdb v0.0.0-20210920082714-1f7dcbb7b2e4
 	github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
-	github.com/flipkart-incubator/gorocksdb v0.0.0-20210507064827-a2162cb9a3f7
+	github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724
 	github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/flipkart-incubator/gorocksdb v0.0.0-20210507064827-a2162cb9a3f7 h1:PxlANvUXyHsBPYk3O8XGekF3WXnJmhYuXwcq6wv0atc=
-github.com/flipkart-incubator/gorocksdb v0.0.0-20210507064827-a2162cb9a3f7/go.mod h1:kvJSXc90Ifw0rxuTxEHKq6UH/7hQ/gd9RKCyD94ctJ0=
+github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724 h1:MPPKn2+XTYb5QNAI/sGSOGS9ZmiSS17HH/VGjHTrjd0=
+github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724/go.mod h1:kvJSXc90Ifw0rxuTxEHKq6UH/7hQ/gd9RKCyD94ctJ0=
 github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938 h1:oOm7+2BbMjCYxuBZdjVJXpqmVe83k5PAMRebsm2DrdE=
 github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938/go.mod h1:p8YOMx5k0TYnOxPB04t0lY6COMRAa7CdEUYo6QIm1y4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724 h1:MPPKn2+XTYb5QNAI/sGSOGS9ZmiSS17HH/VGjHTrjd0=
-github.com/flipkart-incubator/gorocksdb v0.0.0-20210902093326-a9882052e724/go.mod h1:kvJSXc90Ifw0rxuTxEHKq6UH/7hQ/gd9RKCyD94ctJ0=
+github.com/flipkart-incubator/gorocksdb v0.0.0-20210920082714-1f7dcbb7b2e4 h1:9zPLm5QKcBp5xUOBMWhRZPU+iwfl6xJtbSmbazmgy2g=
+github.com/flipkart-incubator/gorocksdb v0.0.0-20210920082714-1f7dcbb7b2e4/go.mod h1:kvJSXc90Ifw0rxuTxEHKq6UH/7hQ/gd9RKCyD94ctJ0=
 github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938 h1:oOm7+2BbMjCYxuBZdjVJXpqmVe83k5PAMRebsm2DrdE=
 github.com/flipkart-incubator/nexus v0.0.0-20210802072935-cc9377cae938/go.mod h1:p8YOMx5k0TYnOxPB04t0lY6COMRAa7CdEUYo6QIm1y4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
Dependent on https://github.com/flipkart-incubator/gorocksdb/pull/3

Backward compatibility: Verified.  Inplace upgrade works without any issues.