### PR TITLE
Expose Engine Internal Metrics via Prometheus

### DIFF
--- a/cmd/dkvsrv/main.go
+++ b/cmd/dkvsrv/main.go
@@ -375,6 +375,7 @@ func newKVStore() (storage.KVStore, storage.ChangePropagator, storage.ChangeAppl
 		if err != nil {
 			dkvLogger.Panic("RocksDB engine init failed", zap.Error(err))
 		}
+
 		return rocksDb, rocksDb, rocksDb, rocksDb
 	case "badger":
 		var badgerDb badger.DB

--- a/internal/storage/badger/metrics.go
+++ b/internal/storage/badger/metrics.go
@@ -1,0 +1,81 @@
+package badger
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewBadgerCollector returns a prometheus Collector for Badger metrics from expvar.
+func (bdb *badgerDB) metricsCollector() {
+	collector := prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
+		"badger_v3_disk_reads_total": prometheus.NewDesc(
+			"badger_disk_reads_total",
+			"Number of cumulative reads by Badger",
+			nil, nil,
+		),
+		"badger_v3_disk_writes_total": prometheus.NewDesc(
+			"badger_disk_writes_total",
+			"Number of cumulative writes by Badger",
+			nil, nil,
+		),
+		"badger_v3_read_bytes": prometheus.NewDesc(
+			"badger_read_bytes",
+			"Number of cumulative bytes read by Badger",
+			nil, nil,
+		),
+		"badger_v3_written_bytes": prometheus.NewDesc(
+			"badger_written_bytes",
+			"Number of cumulative bytes written by Badger",
+			nil, nil,
+		),
+		"badger_v3_lsm_level_gets_total": prometheus.NewDesc(
+			"badger_lsm_level_gets_total",
+			"Total number of LSM gets",
+			[]string{"level"}, nil,
+		),
+		"badger_v3_lsm_bloom_hits_total": prometheus.NewDesc(
+			"badger_lsm_bloom_hits_total",
+			"Total number of LSM bloom hits",
+			[]string{"level"}, nil,
+		),
+		"badger_v3_gets_total": prometheus.NewDesc(
+			"badger_gets_total",
+			"Total number of gets",
+			nil, nil,
+		),
+		"badger_v3_puts_total": prometheus.NewDesc(
+			"badger_puts_total",
+			"Total number of puts",
+			nil, nil,
+		),
+		"badger_v3_blocked_puts_total": prometheus.NewDesc(
+			"badger_blocked_puts_total",
+			"Total number of blocked puts",
+			nil, nil,
+		),
+		"badger_v3_memtable_gets_total": prometheus.NewDesc(
+			"badger_memtable_gets_total",
+			"Total number of memtable gets",
+			nil, nil,
+		),
+		"badger_v3_lsm_size_bytes": prometheus.NewDesc(
+			"badger_lsm_size_bytes",
+			"Size of the LSM in bytes",
+			[]string{"dir"}, nil,
+		),
+		"badger_v3_vlog_size_bytes": prometheus.NewDesc(
+			"badger_vlog_size_bytes",
+			"Size of the value log in bytes",
+			[]string{"dir"}, nil,
+		),
+		"badger_v3_pending_writes_total": prometheus.NewDesc(
+			"badger_pending_writes_total",
+			"Total number of pending writes",
+			[]string{"dir"}, nil,
+		),
+		"badger_v3_compactions_current": prometheus.NewDesc(
+			"badger_compactions_current",
+			"Number of tables being actively compacted",
+			nil, nil,
+		),
+	})
+
+	bdb.opts.promRegistry.MustRegister(collector)
+}

--- a/internal/storage/rocksdb/metrics.go
+++ b/internal/storage/rocksdb/metrics.go
@@ -1,0 +1,69 @@
+package rocksdb
+
+import (
+	"github.com/flipkart-incubator/gorocksdb"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+type rocksDBCollector struct {
+	memTableTotalGauge        *prometheus.Desc
+	memTableUnflushedGauge    *prometheus.Desc
+	memTableReadersTotalGauge *prometheus.Desc
+	cacheTotalGauge           *prometheus.Desc
+	db                        *gorocksdb.DB
+	lgr                       *zap.Logger
+}
+
+func newRocksDBCollector(rdb *rocksDB) *rocksDBCollector {
+	return &rocksDBCollector{
+		memTableTotalGauge: prometheus.NewDesc(
+			prometheus.BuildFQName("rocksdb", "", "memory_usage_memtable_total"),
+			"Rocksdb MemTableTotal estimates memory usage of all mem-tables",
+			nil, nil),
+		memTableUnflushedGauge: prometheus.NewDesc(
+			prometheus.BuildFQName("rocksdb", "", "memory_usage_memtable_unflushed"),
+			"Rocksdb MemTableUnflushed estimates memory usage of unflushed mem-tables",
+			nil, nil),
+		memTableReadersTotalGauge: prometheus.NewDesc(
+			prometheus.BuildFQName("rocksdb", "", "memory_usage_memtable_readers_total"),
+			"Rocksdb MemTableReadersTotal memory usage of table readers (indexes and bloom filters)",
+			nil, nil),
+		cacheTotalGauge: prometheus.NewDesc(
+			prometheus.BuildFQName("rocksdb", "", "memory_usage_cache_total"),
+			"Rocksdb CacheTotal memory usage of cache",
+			nil, nil),
+		db:  rdb.db,
+		lgr: rdb.opts.lgr,
+	}
+
+}
+
+//Each and every collector must implement the Describe function.
+//It essentially writes all descriptors to the prometheus desc channel.
+func (collector *rocksDBCollector) Describe(ch chan<- *prometheus.Desc) {
+	//Update this section with the each metric you create for a given collector
+	ch <- collector.memTableTotalGauge
+	ch <- collector.memTableUnflushedGauge
+	ch <- collector.memTableReadersTotalGauge
+	ch <- collector.cacheTotalGauge
+}
+
+//Collect implements required collect function for all promehteus collectors
+func (collector *rocksDBCollector) Collect(ch chan<- prometheus.Metric) {
+	memoryUsage, err := gorocksdb.GetApproximateMemoryUsageByType([]*gorocksdb.DB{collector.db}, nil)
+	if err != nil {
+		collector.lgr.Error("Failed to get rocksgb memory usage", zap.Error(err))
+	} else {
+		ch <- prometheus.MustNewConstMetric(collector.memTableTotalGauge, prometheus.GaugeValue, float64(memoryUsage.MemTableTotal))
+		ch <- prometheus.MustNewConstMetric(collector.memTableUnflushedGauge, prometheus.GaugeValue, float64(memoryUsage.MemTableUnflushed))
+		ch <- prometheus.MustNewConstMetric(collector.memTableReadersTotalGauge, prometheus.GaugeValue, float64(memoryUsage.MemTableReadersTotal))
+		ch <- prometheus.MustNewConstMetric(collector.cacheTotalGauge, prometheus.GaugeValue, float64(memoryUsage.CacheTotal))
+	}
+}
+
+// metricsCollector collects rocksdB metrics.
+func (rdb *rocksDB) metricsCollector() {
+	collector := newRocksDBCollector(rdb)
+	rdb.opts.promRegistry.MustRegister(collector)
+}

--- a/internal/storage/rocksdb/store.go
+++ b/internal/storage/rocksdb/store.go
@@ -239,6 +239,8 @@ func openStore(opts *rocksDBOpts) (*rocksDB, error) {
 		globalMutation: 0,
 		stat:           storage.NewStat(opts.promRegistry, "rocksdb"),
 	}
+	rocksdb.metricsCollector()
+
 	//TODO: revisit this later after understanding what is the impact of manually triggered compaction
 	//go rocksdb.Compaction()
 	return &rocksdb, nil


### PR DESCRIPTION
```
# HELP rocksdb_memory_usage_cache_total Rocksdb CacheTotal memory usage of cache
# TYPE rocksdb_memory_usage_cache_total gauge
rocksdb_memory_usage_cache_total 0
# HELP rocksdb_memory_usage_memtable_readers_total Rocksdb MemTableReadersTotal memory usage of table readers (indexes and bloom filters)
# TYPE rocksdb_memory_usage_memtable_readers_total gauge
rocksdb_memory_usage_memtable_readers_total 532
# HELP rocksdb_memory_usage_memtable_total Rocksdb MemTableTotal estimates memory usage of all mem-tables
# TYPE rocksdb_memory_usage_memtable_total gauge
rocksdb_memory_usage_memtable_total 4096
# HELP rocksdb_memory_usage_memtable_unflushed Rocksdb MemTableUnflushed estimates memory usage of unflushed mem-tables
# TYPE rocksdb_memory_usage_memtable_unflushed gauge
rocksdb_memory_usage_memtable_unflushed 4096
```