### PR TITLE
rocksdb: Fix segfault due to prom call

### DIFF
--- a/internal/master/service.go
+++ b/internal/master/service.go
@@ -47,9 +47,10 @@ type dkvServiceStat struct {
 	ResponseError *prometheus.CounterVec
 }
 
-func newDKVServiceStat(registry prometheus.Registerer) *dkvServiceStat {
+func newDKVServiceStat(registry prometheus.Registerer, mode string) *dkvServiceStat {
 	RequestLatency := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  stats.Namespace,
+		Subsystem:  mode,
 		Name:       "latency",
 		Help:       "Latency statistics for dkv service",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
@@ -57,6 +58,7 @@ func newDKVServiceStat(registry prometheus.Registerer) *dkvServiceStat {
 	}, []string{"Ops"})
 	ResponseError := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: stats.Namespace,
+		Subsystem: mode,
 		Name:      "error",
 		Help:      "Error count for storage operations",
 	}, []string{"Ops"})
@@ -111,14 +113,9 @@ func (ss *standaloneService) Watch(req *health.HealthCheckRequest, watcher healt
 // NewStandaloneService creates a standalone variant of the DKVService
 // that works only with the local storage.
 func NewStandaloneService(store storage.KVStore, cp storage.ChangePropagator, br storage.Backupable, regionInfo *serverpb.RegionInfo, opts *opts.ServerOpts) DKVService {
-	serviceStat := newDKVServiceStat(opts.PrometheusRegistry)
-	return NewStandaloneServiceWithStats(store, cp, br, regionInfo, opts, serviceStat)
-}
-
-func NewStandaloneServiceWithStats(store storage.KVStore, cp storage.ChangePropagator, br storage.Backupable, regionInfo *serverpb.RegionInfo, opts *opts.ServerOpts, stat *dkvServiceStat) DKVService {
 	rwl := &sync.RWMutex{}
 	regionInfo.Status = serverpb.RegionStatus_LEADER
-	return &standaloneService{store: store, cp: cp, br: br, rwl: rwl, regionInfo: regionInfo, shutdown: make(chan struct{}, 1), opts: opts, stat: stat}
+	return &standaloneService{store, cp, br, rwl, regionInfo, false, make(chan struct{}, 1), opts, newDKVServiceStat(opts.PrometheusRegistry, "standalone")}
 }
 
 func (ss *standaloneService) Put(ctx context.Context, putReq *serverpb.PutRequest) (*serverpb.PutResponse, error) {
@@ -403,13 +400,12 @@ type distributedService struct {
 // that attempts to replicate data across multiple replicas over Nexus.
 func NewDistributedService(kvs storage.KVStore, cp storage.ChangePropagator, br storage.Backupable,
 	raftRepl nexus_api.RaftReplicator, regionInfo *serverpb.RegionInfo, opts *opts.ServerOpts) DKVClusterService {
-	dkvStats := newDKVServiceStat(opts.PrometheusRegistry)
 	return &distributedService{
-		DKVService: NewStandaloneServiceWithStats(kvs, cp, br, regionInfo, opts, dkvStats),
+		DKVService: NewStandaloneService(kvs, cp, br, regionInfo, opts),
 		raftRepl:   raftRepl,
 		shutdown:   make(chan struct{}, 1),
 		opts:       opts,
-		stat:       dkvStats,
+		stat:       newDKVServiceStat(opts.PrometheusRegistry, "distributed"),
 	}
 }
 

--- a/internal/master/service.go
+++ b/internal/master/service.go
@@ -403,7 +403,7 @@ func NewDistributedService(kvs storage.KVStore, cp storage.ChangePropagator, br 
 		raftRepl:   raftRepl,
 		shutdown:   make(chan struct{}, 1),
 		opts:       opts,
-		stat:       newDKVServiceStat(stats.NewPromethousNoopRegistry()),
+		stat:       newDKVServiceStat(opts.PrometheusRegistry),
 	}
 }
 

--- a/internal/master/service.go
+++ b/internal/master/service.go
@@ -47,9 +47,10 @@ type dkvServiceStat struct {
 	ResponseError *prometheus.CounterVec
 }
 
-func newDKVServiceStat(registry prometheus.Registerer) *dkvServiceStat {
+func newDKVServiceStat(registry prometheus.Registerer, mode string) *dkvServiceStat {
 	RequestLatency := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  stats.Namespace,
+		Subsystem:  mode,
 		Name:       "latency",
 		Help:       "Latency statistics for dkv service",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
@@ -57,6 +58,7 @@ func newDKVServiceStat(registry prometheus.Registerer) *dkvServiceStat {
 	}, []string{"Ops"})
 	ResponseError := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: stats.Namespace,
+		Subsystem: mode,
 		Name:      "error",
 		Help:      "Error count for storage operations",
 	}, []string{"Ops"})
@@ -113,7 +115,7 @@ func (ss *standaloneService) Watch(req *health.HealthCheckRequest, watcher healt
 func NewStandaloneService(store storage.KVStore, cp storage.ChangePropagator, br storage.Backupable, regionInfo *serverpb.RegionInfo, opts *opts.ServerOpts) DKVService {
 	rwl := &sync.RWMutex{}
 	regionInfo.Status = serverpb.RegionStatus_LEADER
-	return &standaloneService{store, cp, br, rwl, regionInfo, false, make(chan struct{}, 1), opts, newDKVServiceStat(opts.PrometheusRegistry)}
+	return &standaloneService{store, cp, br, rwl, regionInfo, false, make(chan struct{}, 1), opts, newDKVServiceStat(opts.PrometheusRegistry, "standalone")}
 }
 
 func (ss *standaloneService) Put(ctx context.Context, putReq *serverpb.PutRequest) (*serverpb.PutResponse, error) {
@@ -403,7 +405,7 @@ func NewDistributedService(kvs storage.KVStore, cp storage.ChangePropagator, br 
 		raftRepl:   raftRepl,
 		shutdown:   make(chan struct{}, 1),
 		opts:       opts,
-		stat:       newDKVServiceStat(opts.PrometheusRegistry),
+		stat:       newDKVServiceStat(opts.PrometheusRegistry, "distributed"),
 	}
 }
 

--- a/internal/storage/badger/metrics.go
+++ b/internal/storage/badger/metrics.go
@@ -6,11 +6,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var collector prometheus.Collector
-
 // NewBadgerCollector returns a prometheus Collector for Badger metrics from expvar.
 func (bdb *badgerDB) metricsCollector() {
-	collector = prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
+	bdb.stat.StoreMetricsCollector = prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
 		"badger_v3_disk_reads_total": prometheus.NewDesc(
 			prometheus.BuildFQName(stats.Namespace, "badger", "disk_reads_total"),
 			"Number of cumulative reads by Badger",
@@ -84,11 +82,11 @@ func (bdb *badgerDB) metricsCollector() {
 	})
 	bdb.stat = storage.NewStat("badger")
 	bdb.opts.promRegistry.MustRegister(bdb.stat.RequestLatency, bdb.stat.ResponseError)
-	bdb.opts.promRegistry.MustRegister(collector)
+	bdb.opts.promRegistry.MustRegister(bdb.stat.StoreMetricsCollector)
 }
 
 func (bdb *badgerDB) unRegisterMetricsCollector() {
-	bdb.opts.promRegistry.Unregister(collector)
+	bdb.opts.promRegistry.Unregister(bdb.stat.StoreMetricsCollector)
 	bdb.opts.promRegistry.Unregister(bdb.stat.RequestLatency)
 	bdb.opts.promRegistry.Unregister(bdb.stat.ResponseError)
 }

--- a/internal/storage/badger/metrics.go
+++ b/internal/storage/badger/metrics.go
@@ -2,12 +2,15 @@ package badger
 
 import (
 	"github.com/flipkart-incubator/dkv/internal/stats"
+	"github.com/flipkart-incubator/dkv/internal/storage"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var collector prometheus.Collector
+
 // NewBadgerCollector returns a prometheus Collector for Badger metrics from expvar.
 func (bdb *badgerDB) metricsCollector() {
-	collector := prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
+	collector = prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
 		"badger_v3_disk_reads_total": prometheus.NewDesc(
 			prometheus.BuildFQName(stats.Namespace, "badger", "disk_reads_total"),
 			"Number of cumulative reads by Badger",
@@ -79,6 +82,13 @@ func (bdb *badgerDB) metricsCollector() {
 			nil, nil,
 		),
 	})
-
+	bdb.stat = storage.NewStat("badger")
+	bdb.opts.promRegistry.MustRegister(bdb.stat.RequestLatency, bdb.stat.ResponseError)
 	bdb.opts.promRegistry.MustRegister(collector)
+}
+
+func (bdb *badgerDB) unRegisterMetricsCollector() {
+	bdb.opts.promRegistry.Unregister(collector)
+	bdb.opts.promRegistry.Unregister(bdb.stat.RequestLatency)
+	bdb.opts.promRegistry.Unregister(bdb.stat.ResponseError)
 }

--- a/internal/storage/badger/metrics.go
+++ b/internal/storage/badger/metrics.go
@@ -8,6 +8,7 @@ import (
 
 // NewBadgerCollector returns a prometheus Collector for Badger metrics from expvar.
 func (bdb *badgerDB) metricsCollector() {
+	bdb.stat = storage.NewStat("badger")
 	bdb.stat.StoreMetricsCollector = prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
 		"badger_v3_disk_reads_total": prometheus.NewDesc(
 			prometheus.BuildFQName(stats.Namespace, "badger", "disk_reads_total"),
@@ -80,7 +81,6 @@ func (bdb *badgerDB) metricsCollector() {
 			nil, nil,
 		),
 	})
-	bdb.stat = storage.NewStat("badger")
 	bdb.opts.promRegistry.MustRegister(bdb.stat.RequestLatency, bdb.stat.ResponseError)
 	bdb.opts.promRegistry.MustRegister(bdb.stat.StoreMetricsCollector)
 }

--- a/internal/storage/badger/store.go
+++ b/internal/storage/badger/store.go
@@ -186,12 +186,13 @@ func openStore(bdbOpts *bdgrOpts) (*badgerDB, error) {
 		return nil, err
 	}
 
-	bdb := badgerDB{db, bdbOpts, storage.NewStat(bdbOpts.promRegistry, "badger"), 0}
+	bdb := badgerDB{db: db, opts: bdbOpts, globalMutation: 0}
 	bdb.metricsCollector()
 	return &bdb, nil
 }
 
 func (bdb *badgerDB) Close() error {
+	bdb.unRegisterMetricsCollector()
 	bdb.db.Close()
 	return nil
 }

--- a/internal/storage/rocksdb/metrics.go
+++ b/internal/storage/rocksdb/metrics.go
@@ -64,18 +64,16 @@ func (collector *rocksDBCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-var collector prometheus.Collector
-
 // metricsCollector collects rocksdB metrics.
 func (rdb *rocksDB) metricsCollector() {
 	rdb.stat = storage.NewStat("rocksdb")
 	rdb.opts.promRegistry.MustRegister(rdb.stat.RequestLatency, rdb.stat.ResponseError)
-	collector = newRocksDBCollector(rdb)
-	rdb.opts.promRegistry.MustRegister(collector)
+	rdb.stat.StoreMetricsCollector = newRocksDBCollector(rdb)
+	rdb.opts.promRegistry.MustRegister(rdb.stat.StoreMetricsCollector)
 }
 
 func (rdb *rocksDB) unRegisterMetricsCollector() {
-	rdb.opts.promRegistry.Unregister(collector)
+	rdb.opts.promRegistry.Unregister(rdb.stat.StoreMetricsCollector)
 	rdb.opts.promRegistry.Unregister(rdb.stat.RequestLatency)
 	rdb.opts.promRegistry.Unregister(rdb.stat.ResponseError)
 }

--- a/internal/storage/rocksdb/metrics.go
+++ b/internal/storage/rocksdb/metrics.go
@@ -5,6 +5,7 @@ import (
 	"github.com/flipkart-incubator/gorocksdb"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	"time"
 )
 
 type rocksDBCollector struct {
@@ -65,6 +66,10 @@ func (collector *rocksDBCollector) Collect(ch chan<- prometheus.Metric) {
 
 // metricsCollector collects rocksdB metrics.
 func (rdb *rocksDB) metricsCollector() {
-	collector := newRocksDBCollector(rdb)
-	rdb.opts.promRegistry.MustRegister(collector)
+	// apply a 2sec timer. Why? Throws segfault error of the rdb if called right after opening..
+	// TODO: find a better option to handle this.
+	time.AfterFunc(2*time.Second, func() {
+		collector := newRocksDBCollector(rdb)
+		rdb.opts.promRegistry.MustRegister(collector)
+	})
 }

--- a/internal/storage/rocksdb/store.go
+++ b/internal/storage/rocksdb/store.go
@@ -237,7 +237,6 @@ func openStore(opts *rocksDBOpts) (*rocksDB, error) {
 		optimTrxnDB:    optimTrxnDB,
 		opts:           opts,
 		globalMutation: 0,
-		stat:           storage.NewStat(opts.promRegistry, "rocksdb"),
 	}
 	rocksdb.metricsCollector()
 
@@ -266,6 +265,7 @@ func (rdb *rocksDB) Compaction() error {
 }
 
 func (rdb *rocksDB) Close() error {
+	rdb.unRegisterMetricsCollector()
 	rdb.optimTrxnDB.Close()
 	//rdb.opts.destroy()
 	return nil

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Stat struct {
-	RequestLatency *prometheus.SummaryVec
-	ResponseError  *prometheus.CounterVec
+	RequestLatency        *prometheus.SummaryVec
+	ResponseError         *prometheus.CounterVec
+	StoreMetricsCollector prometheus.Collector
 }
 
 func NewStat(engine string) *Stat {
@@ -31,7 +32,7 @@ func NewStat(engine string) *Stat {
 		Name:      fmt.Sprintf("storage_error_%s", engine),
 		Help:      fmt.Sprintf("Error count for %s storage operations", engine),
 	}, []string{stats.Ops})
-	return &Stat{RequestLatency, ResponseError}
+	return &Stat{RequestLatency: RequestLatency, ResponseError: ResponseError}
 }
 
 // A KVStore represents the key value store that provides

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -18,7 +18,7 @@ type Stat struct {
 	ResponseError  *prometheus.CounterVec
 }
 
-func NewStat(registry prometheus.Registerer, engine string) *Stat {
+func NewStat(engine string) *Stat {
 	RequestLatency := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  stats.Namespace,
 		Name:       fmt.Sprintf("storage_latency_%s", engine),
@@ -31,7 +31,6 @@ func NewStat(registry prometheus.Registerer, engine string) *Stat {
 		Name:      fmt.Sprintf("storage_error_%s", engine),
 		Help:      fmt.Sprintf("Error count for %s storage operations", engine),
 	}, []string{stats.Ops})
-	registry.MustRegister(RequestLatency, ResponseError)
 	return &Stat{RequestLatency, ResponseError}
 }
 


### PR DESCRIPTION
Trace

```
2023-03-29 16:05:52.700810 I | rafthttp: established a TCP streaming connection with peer 7ff32a0d420fb915 (stream Message reader)
raft2023/03/29 16:05:52 INFO: raft.node: 11f103710b704dbe elected leader 295564b4abea15bd at term 86
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa pc=0xa]

runtime stack:
runtime.throw({0x14920fc?, 0x0?})
	/usr/local/go/src/runtime/panic.go:992 +0x71
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:802 +0x3a9

goroutine 148 [syscall]:
runtime.cgocall(0xc9e730, 0xc00049fd50)
	/usr/local/go/src/runtime/cgocall.go:157 +0x5c fp=0xc00049fd28 sp=0xc00049fcf0 pc=0x46381c
github.com/flipkart-incubator/gorocksdb._Cfunc_rocksdb_approximate_memory_usage_create(0x7f5448000c80, 0xc000010050)
	_cgo_gotypes.go:412 +0x4d fp=0xc00049fd50 sp=0xc00049fd28 pc=0xbe5d0d
github.com/flipkart-incubator/gorocksdb.GetApproximateMemoryUsageByType.func4(0x7f5448000c80, 0x0?)
	/root/go/pkg/mod/github.com/flipkart-incubator/gorocksdb@v0.0.0-20210920082714-1f7dcbb7b2e4/memory_usage.go:43 +0x71 fp=0xc00049fd88 sp=0xc00049fd50 pc=0xc05691
github.com/flipkart-incubator/gorocksdb.GetApproximateMemoryUsageByType({0xc00049fe88, 0x1, 0xc00028b290?}, {0x0, 0x0, 0xc00028b140?})
	/root/go/pkg/mod/github.com/flipkart-incubator/gorocksdb@v0.0.0-20210920082714-1f7dcbb7b2e4/memory_usage.go:43 +0x165 fp=0xc00049fe40 sp=0xc00049fd88 pc=0xc05025
github.com/flipkart-incubator/dkv/internal/storage/rocksdb.(*rocksDBCollector).Collect(0xc00046c360, 0xc00049ff60?)
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/internal/storage/rocksdb/metrics.go:55 +0x5e fp=0xc00049ff30 sp=0xc00049fe40 pc=0xc3aa9e
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/root/go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:446 +0xfb fp=0xc00049ffe0 sp=0xc00049ff30 pc=0x92b85b
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc00049ffe8 sp=0xc00049ffe0 pc=0x4c8ba1
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/root/go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:538 +0xb0b

goroutine 1 [syscall]:
github.com/flipkart-incubator/gorocksdb._Cfunc_rocksdb_optimistictransactiondb_open_column_families(0x2c4ed00, 0x7f542000a1f0, 0x2, 0xc000466180, 0xc0005756e0, 0xc0005756f0, 0xc000522038)
	_cgo_gotypes.go:2449 +0x4d
github.com/flipkart-incubator/gorocksdb.OpenOptimisticTransactionDbColumnFamilies.func3(0x1469f5b?, 0x3?, 0x2, 0xc0002294e8, 0xc0002294d0, 0xc000229500, 0x49fc45?)
	/root/go/pkg/mod/github.com/flipkart-incubator/gorocksdb@v0.0.0-20210920082714-1f7dcbb7b2e4/optim_transactiondb.go:81 +0x1b1
github.com/flipkart-incubator/gorocksdb.OpenOptimisticTransactionDbColumnFamilies(0xc00014cf80, {0xc000121940, 0x19}, {0xc0001192a0, 0x2, 0xc000121940?}, {0xc0002295c0, 0x2, 0xc000522010?})
	/root/go/pkg/mod/github.com/flipkart-incubator/gorocksdb@v0.0.0-20210920082714-1f7dcbb7b2e4/optim_transactiondb.go:81 +0x2fb
github.com/flipkart-incubator/dkv/internal/storage/rocksdb.openStore(0xc0003c0510)
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/internal/storage/rocksdb/store.go:227 +0xf2
github.com/flipkart-incubator/dkv/internal/storage/rocksdb.(*rocksDB).replaceDB(0xc00014d000, {0xc0107e01e0, 0x41})
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/internal/storage/rocksdb/store.go:291 +0x3dd
github.com/flipkart-incubator/dkv/internal/storage/rocksdb.(*rocksDB).PutSnapshot(0xc00014d000, {0x15c26e0, 0xc000210038})
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/internal/storage/rocksdb/store.go:594 +0x6d1
github.com/flipkart-incubator/dkv/internal/sync.(*dkvReplStore).Restore(0xc0107e00f0?, {0x15c26e0?, 0xc000210038?})
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/internal/sync/repl.go:129 +0x2b
github.com/flipkart-incubator/nexus/internal/raft.(*replicator).restoreFromSnapshot(0xc0001fe230)
	/root/go/pkg/mod/github.com/flipkart-incubator/nexus@v0.0.0-20220725092354-3772bb325062/internal/raft/replicator.go:267 +0x1f2
github.com/flipkart-incubator/nexus/internal/raft.(*replicator).Start(0xc0001fe230)
	/root/go/pkg/mod/github.com/flipkart-incubator/nexus@v0.0.0-20220725092354-3772bb325062/internal/raft/replicator.go:77 +0x32
main.newDKVReplicator({0x15c8da0?, 0xc00014d000})
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/cmd/dkvsrv/main.go:472 +0x13f
main.main()
	/mnt/disks/build_infra/repos/dkv-build-2071200/git-repo/fk-3p-dkv/dkv/cmd/dkvsrv/main.go:165 +0xa2b

goroutine 7 [select]:
github.com/kpango/fastime.(*Fastime).StartTimerD.func1()
	/root/go/pkg/mod/github.com/kpango/fastime@v1.0.16/fastime.go:192 +0x11e
created by github.com/kpango/fastime.(*Fastime).StartTimerD
	/root/go/pkg/mod/github.com/kpango/fastime@v1.0.16/fastime.go:185 +0x145

```
 